### PR TITLE
Add CaretPositionChanged event to SyntaxRenderer

### DIFF
--- a/Sandra.Chess/PGN/PGNSyntax.cs
+++ b/Sandra.Chess/PGN/PGNSyntax.cs
@@ -230,6 +230,7 @@ namespace Sandra.PGN
 
         public BlackToMoveEllipsisSymbol(PGNPly ply)
         {
+            if (ply == null) throw new ArgumentNullException(nameof(ply));
             Ply = ply;
         }
 
@@ -247,6 +248,7 @@ namespace Sandra.PGN
 
         public MoveCounterSymbol(PGNPly ply)
         {
+            if (ply == null) throw new ArgumentNullException(nameof(ply));
             Ply = ply;
         }
 
@@ -264,6 +266,7 @@ namespace Sandra.PGN
 
         public FormattedMoveSymbol(PGNPly ply)
         {
+            if (ply == null) throw new ArgumentNullException(nameof(ply));
             Ply = ply;
         }
 

--- a/Sandra.Chess/PGN/PGNSyntax.cs
+++ b/Sandra.Chess/PGN/PGNSyntax.cs
@@ -291,4 +291,13 @@ namespace Sandra.PGN
         public PGNMoveSearcher(Chess.MoveTree needle) { this.needle = needle; }
         public override bool VisitFormattedMoveSymbol(FormattedMoveSymbol symbol) => symbol.Ply.Variation.MoveTree == needle;
     }
+
+    public class PGNActivePlyDetector : PGNTerminalSymbolVisitor<PGNPly>
+    {
+        public override PGNPly VisitBlackToMoveEllipsisSymbol(BlackToMoveEllipsisSymbol symbol) => symbol.Ply;
+        public override PGNPly VisitFormattedMoveSymbol(FormattedMoveSymbol symbol) => symbol.Ply;
+        public override PGNPly VisitMoveCounterSymbol(MoveCounterSymbol symbol) => symbol.Ply;
+        public override PGNPly VisitSideLineEndSymbol(SideLineEndSymbol symbol) => symbol.SideLine.Plies[0].Ply;
+        public override PGNPly VisitSideLineStartSymbol(SideLineStartSymbol symbol) => symbol.SideLine.Plies[symbol.SideLine.Plies.Count - 1].Ply;
+    }
 }

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -52,6 +52,7 @@ namespace Sandra.UI.WF
         {
             BorderStyle = BorderStyle.None;
             syntaxRenderer = SyntaxRenderer<PGNTerminalSymbol>.AttachTo(this);
+            syntaxRenderer.CaretPositionChanged += caretPositionChanged;
             BackColor = Color.White;
             ForeColor = Color.Black;
             applyDefaultStyle();
@@ -283,9 +284,9 @@ namespace Sandra.UI.WF
             }
         }
 
-        protected override void OnSelectionChanged(EventArgs e)
+        private void caretPositionChanged(SyntaxRenderer<PGNTerminalSymbol> sender, EventArgs e)
         {
-            if (!IsUpdating && SelectionLength == 0 && hasGameAndMoveFormatter)
+            if (hasGameAndMoveFormatter)
             {
                 int selectionStart = SelectionStart;
 
@@ -355,8 +356,6 @@ namespace Sandra.UI.WF
                     }
                 }
             }
-
-            base.OnSelectionChanged(e);
         }
     }
 }

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -288,48 +288,28 @@ namespace Sandra.UI.WF
         {
             if (hasGameAndMoveFormatter)
             {
-                int selectionStart = SelectionStart;
+                TextElement<PGNTerminalSymbol> activeElement = e.ElementBefore;
+                PGNPly pgnPly;
 
-                int elemIndex;
-                if (selectionStart == 0)
-                {
-                    // Go to the initial position when the caret is at the start.
-                    elemIndex = -1;
-                }
-                else
-                {
-                    List<int> startIndexes = syntaxRenderer.Elements.Select(x => x.Start).ToList();
-
-                    // Get the index of the element that contains the caret.
-                    elemIndex = startIndexes.BinarySearch(selectionStart);
-                    if (elemIndex < 0) elemIndex = ~elemIndex - 1;
-
-                    // Look for an element which delimits a move.
-                    while (elemIndex >= 0
-                        && !(syntaxRenderer.Elements[elemIndex].TerminalSymbol is MoveCounterSymbol)
-                        && !(syntaxRenderer.Elements[elemIndex].TerminalSymbol is FormattedMoveSymbol))
-                    {
-                        elemIndex--;
-                    }
-                }
-
-                TextElement<PGNTerminalSymbol> newActiveMoveElement;
-                Chess.MoveTree newActiveTree;
-                if (elemIndex < 0)
+                if (activeElement == null)
                 {
                     // Exceptional case to go to the initial position.
-                    newActiveMoveElement = null;
-                    newActiveTree = game.Game.MoveTree;
+                    pgnPly = null;
                 }
                 else
                 {
-                    // If at a MoveCounter, go forward until the actual FormattedMove.
-                    while (!(syntaxRenderer.Elements[elemIndex].TerminalSymbol is FormattedMoveSymbol)) elemIndex++;
+                    // Prefer to attach to a non-space element.
+                    // Use assumption that the terminal symbol list nowhere contains two adjacent SpaceSymbols.
+                    // Also use assumption that the terminal symbol list neither starts nor ends with a SpaceSymbol.
+                    if (activeElement.TerminalSymbol is SpaceSymbol && e.ElementAfter != null)
+                    {
+                        activeElement = e.ElementAfter;
+                    }
 
-                    // Go to the position after the selected move.
-                    newActiveMoveElement = syntaxRenderer.Elements[elemIndex];
-                    newActiveTree = ((FormattedMoveSymbol)newActiveMoveElement.TerminalSymbol).Ply.Variation.MoveTree;
+                    pgnPly = new PGNActivePlyDetector().Visit(activeElement.TerminalSymbol);
                 }
+
+                Chess.MoveTree newActiveTree = pgnPly == null ? game.Game.MoveTree : pgnPly.Variation.MoveTree;
 
                 // Update the active move index in the game.
                 if (game.Game.ActiveTree != newActiveTree)
@@ -344,14 +324,19 @@ namespace Sandra.UI.WF
                         }
 
                         game.Game.SetActiveTree(newActiveTree);
-
                         game.ActiveMoveTreeUpdated();
                         ActionHandler.Invalidate();
 
-                        if (newActiveMoveElement != null)
+                        // Search for the current active move element to set its font.
+                        PGNMoveSearcher newActiveTreeSearcher = new PGNMoveSearcher(game.Game.ActiveTree);
+                        foreach (TextElement<PGNTerminalSymbol> textElement in syntaxRenderer.Elements)
                         {
-                            currentActiveMoveStyleElement = newActiveMoveElement;
-                            applyStyle(newActiveMoveElement, activeMoveStyle);
+                            if (newActiveTreeSearcher.Visit(textElement.TerminalSymbol))
+                            {
+                                currentActiveMoveStyleElement = textElement;
+                                applyStyle(textElement, activeMoveStyle);
+                                break;
+                            }
                         }
                     }
                 }

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -284,7 +284,7 @@ namespace Sandra.UI.WF
             }
         }
 
-        private void caretPositionChanged(SyntaxRenderer<PGNTerminalSymbol> sender, EventArgs e)
+        private void caretPositionChanged(SyntaxRenderer<PGNTerminalSymbol> sender, CaretPositionChangedEventArgs<PGNTerminalSymbol> e)
         {
             if (hasGameAndMoveFormatter)
             {

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -111,4 +111,39 @@ namespace Sandra.UI.WF
             }
         }
     }
+
+    /// <summary>
+    /// Provides data for the <see cref="SyntaxRenderer{TTerminal}.CaretPositionChanged"/> event.
+    /// </summary>
+    public class CaretPositionChangedEventArgs<TTerminal> : EventArgs
+    {
+        /// <summary>
+        /// Gets the text element immediately before the caret, or null if the caret is at the start of the text.
+        /// If the caret is inside a text element, <see cref="ElementBefore"/> returns the same element as <see cref="ElementAfter"/>.
+        /// </summary>
+        public TextElement<TTerminal> ElementBefore { get; }
+
+        /// <summary>
+        /// Gets the text element immediately after the caret, or null if the caret is at the end of the text.
+        /// If the caret is inside a text element, <see cref="ElementAfter"/> returns the same element as <see cref="ElementBefore"/>.
+        /// </summary>
+        public TextElement<TTerminal> ElementAfter { get; }
+
+        /// <summary>
+        /// Returns the relative position of the caret in <see cref="ElementAfter"/>, or 0 if <see cref="ElementAfter"/> is null.
+        /// </summary>
+        public int RelativeCaretIndex { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CaretPositionChangedEventArgs"/> class.
+        /// </summary>
+        internal CaretPositionChangedEventArgs(TextElement<TTerminal> elementBefore,
+                                               TextElement<TTerminal> elementAfter,
+                                               int relativeCaretIndex)
+        {
+            ElementBefore = elementBefore;
+            ElementAfter = elementAfter;
+            RelativeCaretIndex = relativeCaretIndex;
+        }
+    }
 }

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -110,6 +110,7 @@ namespace Sandra.UI.WF
             elementIndexes.Clear();
             elements.Clear();
             RenderTarget.Clear();
+            assertInvariants();
         }
 
         public void RemoveFrom(int index)

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -156,7 +156,7 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Occurs when the position of the caret is updated by the user, when no text is selected.
         /// </summary>
-        public event Action<SyntaxRenderer<TTerminal>, EventArgs> CaretPositionChanged;
+        public event Action<SyntaxRenderer<TTerminal>, CaretPositionChangedEventArgs<TTerminal>> CaretPositionChanged;
 
         private void tryInvokeCaretPositionChanged()
         {
@@ -165,7 +165,16 @@ namespace Sandra.UI.WF
             // Also check SelectionLength so the event is not raised for non-empty selections.
             if (!RenderTarget.IsUpdating && RenderTarget.SelectionLength == 0)
             {
-                CaretPositionChanged?.Invoke(this, EventArgs.Empty);
+                int selectionStart = RenderTarget.SelectionStart;
+
+                TextElement<TTerminal> elementBefore = GetElementBefore(selectionStart);
+                TextElement<TTerminal> elementAfter = GetElementAfter(selectionStart);
+                int relativeCaretIndex = elementAfter == null ? 0 : selectionStart - elementAfter.Start;
+
+                var eventArgs = new CaretPositionChangedEventArgs<TTerminal>(elementBefore,
+                                                                             elementAfter,
+                                                                             relativeCaretIndex);
+                CaretPositionChanged?.Invoke(this, eventArgs);
             }
         }
     }

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -44,6 +44,7 @@ namespace Sandra.UI.WF
 
             renderTarget.ReadOnly = true;
             renderTarget.Clear();
+            renderTarget.SelectionChanged += (_, __) => tryInvokeCaretPositionChanged();
         }
 
         internal readonly UpdatableRichTextBox RenderTarget;
@@ -92,6 +93,22 @@ namespace Sandra.UI.WF
             RenderTarget.SelectedText = string.Empty;
             RenderTarget.ReadOnly = true;
             elements.RemoveRange(index, elements.Count - index);
+        }
+
+        /// <summary>
+        /// Occurs when the position of the caret is updated by the user, when no text is selected.
+        /// </summary>
+        public event Action<SyntaxRenderer<TTerminal>, EventArgs> CaretPositionChanged;
+
+        private void tryInvokeCaretPositionChanged()
+        {
+            // Ignore updates as a result of all kinds of calls to Select()/SelectAll().
+            // This is only to detect caret updates by interacting with the control.
+            // Also check SelectionLength so the event is not raised for non-empty selections.
+            if (!RenderTarget.IsUpdating && RenderTarget.SelectionLength == 0)
+            {
+                CaretPositionChanged?.Invoke(this, EventArgs.Empty);
+            }
         }
     }
 }

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -108,6 +108,7 @@ namespace Sandra.UI.WF
         public void Clear()
         {
             elementIndexes.Clear();
+            elements.ForEach(e => e.Detach());
             elements.Clear();
             RenderTarget.Clear();
             assertInvariants();
@@ -125,6 +126,7 @@ namespace Sandra.UI.WF
             RenderTarget.ReadOnly = true;
 
             elementIndexes.RemoveRange(textStart, textLength);
+            elements.Skip(index).ForEach(e => e.Detach());
             elements.RemoveRange(index, elements.Count - index);
 
             assertInvariants();

--- a/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
+++ b/Sandra.UI.WF/RichTextBox/SyntaxRenderer.cs
@@ -130,6 +130,29 @@ namespace Sandra.UI.WF
         }
 
         /// <summary>
+        /// Gets the length of the generated text.
+        /// </summary>
+        public int TextLength => elementIndexes.Count;
+
+        /// <summary>
+        /// Returns the text element before the given position. Returns null if the position is at the start of the text.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="position"/> is less than 0 or greater than or equal to <see cref="TextLength"/>.
+        /// </exception>
+        public TextElement<TTerminal> GetElementBefore(int position)
+            => position == 0 ? null : elements[elementIndexes[position - 1]];
+
+        /// <summary>
+        /// Returns the text element after the given position. Returns null if the position is at the end of the text.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="position"/> is less than 0 or greater than or equal to <see cref="TextLength"/>.
+        /// </exception>
+        public TextElement<TTerminal> GetElementAfter(int position)
+            => position == elementIndexes.Count ? null : elements[elementIndexes[position]];
+
+        /// <summary>
         /// Occurs when the position of the caret is updated by the user, when no text is selected.
         /// </summary>
         public event Action<SyntaxRenderer<TTerminal>, EventArgs> CaretPositionChanged;

--- a/Sandra.UI.WF/RichTextBox/TextElement.cs
+++ b/Sandra.UI.WF/RichTextBox/TextElement.cs
@@ -16,6 +16,8 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
+using System;
+
 namespace Sandra.UI.WF
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace Sandra.UI.WF
     /// </typeparam>
     public sealed class TextElement<TTerminal>
     {
-        private readonly SyntaxRenderer<TTerminal> renderer;
+        private SyntaxRenderer<TTerminal> renderer;
 
         internal TextElement(SyntaxRenderer<TTerminal> renderer)
         {
@@ -39,10 +41,18 @@ namespace Sandra.UI.WF
         public int Start { get; internal set; }
         public int Length { get; internal set; }
 
+        private void throwIfNoRenderer()
+        {
+            if (renderer == null)
+            {
+                throw new InvalidOperationException($"{nameof(TextElement<TTerminal>)} has no renderer.");
+            }
+        }
+
         /// <summary>
         /// Returns the text element before this element. Returns null if this is the first text element.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// This element has been removed from a renderer.
         /// </exception>
         public TextElement<TTerminal> GetPreviousElement() => renderer.GetElementBefore(Start);
@@ -50,7 +60,7 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Returns the text element before this element. Returns null if this is the first text element.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// This element has been removed from a renderer.
         /// </exception>
         public TextElement<TTerminal> GetNextElement() => renderer.GetElementAfter(Start + Length);
@@ -58,7 +68,7 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Sets the caret directly before this text element and brings it into view.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// This element has been removed from a renderer.
         /// </exception>
         public void BringIntoViewBefore()
@@ -70,13 +80,18 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Sets the caret directly after this text element and brings it into view.
         /// </summary>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// This element has been removed from a renderer.
         /// </exception>
         public void BringIntoViewAfter()
         {
             renderer.RenderTarget.Select(Start + Length, 0);
             renderer.RenderTarget.ScrollToCaret();
+        }
+
+        internal void Detach()
+        {
+            renderer = null;
         }
     }
 }

--- a/Sandra.UI.WF/RichTextBox/TextElement.cs
+++ b/Sandra.UI.WF/RichTextBox/TextElement.cs
@@ -40,6 +40,22 @@ namespace Sandra.UI.WF
         public int Length { get; internal set; }
 
         /// <summary>
+        /// Returns the text element before this element. Returns null if this is the first text element.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// This element is not part of a renderer.
+        /// </exception>
+        public TextElement<TTerminal> GetPreviousElement() => renderer.GetElementBefore(Start);
+
+        /// <summary>
+        /// Returns the text element before this element. Returns null if this is the first text element.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// This element is not part of a renderer.
+        /// </exception>
+        public TextElement<TTerminal> GetNextElement() => renderer.GetElementAfter(Start + Length);
+
+        /// <summary>
         /// Sets the caret directly before this text element and brings it into view.
         /// </summary>
         public void BringIntoViewBefore()

--- a/Sandra.UI.WF/RichTextBox/TextElement.cs
+++ b/Sandra.UI.WF/RichTextBox/TextElement.cs
@@ -42,22 +42,25 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Returns the text element before this element. Returns null if this is the first text element.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// This element is not part of a renderer.
+        /// <exception cref="System.InvalidOperationException">
+        /// This element has been removed from a renderer.
         /// </exception>
         public TextElement<TTerminal> GetPreviousElement() => renderer.GetElementBefore(Start);
 
         /// <summary>
         /// Returns the text element before this element. Returns null if this is the first text element.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// This element is not part of a renderer.
+        /// <exception cref="System.InvalidOperationException">
+        /// This element has been removed from a renderer.
         /// </exception>
         public TextElement<TTerminal> GetNextElement() => renderer.GetElementAfter(Start + Length);
 
         /// <summary>
         /// Sets the caret directly before this text element and brings it into view.
         /// </summary>
+        /// <exception cref="System.InvalidOperationException">
+        /// This element has been removed from a renderer.
+        /// </exception>
         public void BringIntoViewBefore()
         {
             renderer.RenderTarget.Select(Start, 0);
@@ -67,6 +70,9 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Sets the caret directly after this text element and brings it into view.
         /// </summary>
+        /// <exception cref="System.InvalidOperationException">
+        /// This element has been removed from a renderer.
+        /// </exception>
         public void BringIntoViewAfter()
         {
             renderer.RenderTarget.Select(Start + Length, 0);

--- a/Sandra/LinqExtensions.cs
+++ b/Sandra/LinqExtensions.cs
@@ -117,5 +117,28 @@ namespace System.Linq
                 yield return element;
             }
         }
+
+        /// <summary>
+        /// Performs an action on each element of a sequence.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements of <paramref name="source"/>.
+        /// </typeparam>
+        /// <param name="source">
+        /// A sequence of elements.
+        /// </param>
+        /// <param name="action">
+        /// The action to perform on each element of the sequence.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="action"/> is null.
+        /// </exception>
+        public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
+        {
+            foreach (var element in source)
+            {
+                action(element);
+            }
+        }
     }
 }


### PR DESCRIPTION
Add CaretPositionChanged event to SyntaxRenderer and use this new event to improve active ply selection in the MovesTextBox.