### PR TITLE
Add local preferences

### DIFF
--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -1,8 +1,10 @@
 // There are generally two copies of this file, one in the directory where
 // SandraChess.exe is located (Default.settings), and one that lives in the
-// local application data folder. Preferences in the latter file override those
-// that are specified in the default. In the majority of cases, only the latter
-// file is changed, while the default settings serve as a template.
+// local application data folder.
+// 
+// Preferences in the latter file override those that are specified in the
+// default. In the majority of cases, only the latter file is changed, while the
+// default settings serve as a template.
 {
   // Subfolder of %APPDATA%/Local which should be used to store persistent data.
   // This includes the auto-save file, or e.g. a preferences file. Use forward

--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -1,3 +1,8 @@
+// There are generally two copies of this file, one in the directory where
+// SandraChess.exe is located (Default.settings), and one that lives in the
+// local application data folder. Preferences in the latter file override those
+// that are specified in the default. In the majority of cases, only the latter
+// file is changed, while the default settings serve as a template.
 {
   // Subfolder of %APPDATA%/Local which should be used to store persistent data.
   // This includes the auto-save file, or e.g. a preferences file. Use forward

--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -11,11 +11,11 @@
   // slashes to separate directories, an unrecognized escape sequence such as in
   // "Test\Test" renders the whole file unusable.
   "app_data_sub_folder_name": "SandraChess",
-  
+
   // File name in the %APPDATA%/Local subfolder which contains the user-specific
   // preferences.
   "local_preferences_file_name": "Preferences.settings",
-  
+
   // The number of plies (=half moves) to move forward of backward in a game for
   // fast navigation. This value must be between 2 and 40.
   "fast_navigation_ply_count": 10

--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -1,7 +1,11 @@
 {
-    // Subfolder of %APPDATA%/Local which should be used to store persistent data.
-    // This includes the auto-save file, or e.g. a preferences file.
-    // Use forward slashes to separate directories, an unrecognized escape
-    // sequence such as in "Test\Test" renders the whole file unusable.
-    "app_data_sub_folder_name": "SandraChess"
+  // Subfolder of %APPDATA%/Local which should be used to store persistent data.
+  // This includes the auto-save file, or e.g. a preferences file.
+  // Use forward slashes to separate directories, an unrecognized escape
+  // sequence such as in "Test\Test" renders the whole file unusable.
+  "app_data_sub_folder_name": "SandraChess",
+
+  // The number of plies (=half moves) to move forward of backward in a game for
+  // fast navigation. This value must be between 2 and 40.
+  "fast_navigation_ply_count": 10
 }

--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -12,6 +12,10 @@
   // "Test\Test" renders the whole file unusable.
   "app_data_sub_folder_name": "SandraChess",
   
+  // File name in the %APPDATA%/Local subfolder which contains the user-specific
+  // preferences.
+  "local_preferences_file_name": "Preferences.settings",
+  
   // The number of plies (=half moves) to move forward of backward in a game for
   // fast navigation. This value must be between 2 and 40.
   "fast_navigation_ply_count": 10

--- a/Sandra.UI.WF.Chess/DefaultSettings.json
+++ b/Sandra.UI.WF.Chess/DefaultSettings.json
@@ -1,10 +1,10 @@
 {
   // Subfolder of %APPDATA%/Local which should be used to store persistent data.
-  // This includes the auto-save file, or e.g. a preferences file.
-  // Use forward slashes to separate directories, an unrecognized escape
-  // sequence such as in "Test\Test" renders the whole file unusable.
+  // This includes the auto-save file, or e.g. a preferences file. Use forward
+  // slashes to separate directories, an unrecognized escape sequence such as in
+  // "Test\Test" renders the whole file unusable.
   "app_data_sub_folder_name": "SandraChess",
-
+  
   // The number of plies (=half moves) to move forward of backward in a game for
   // fast navigation. This value must be between 2 and 40.
   "fast_navigation_ply_count": 10

--- a/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
+++ b/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
@@ -286,7 +286,7 @@ namespace Sandra.UI.WF
             if (Game.IsFirstMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                Program.GetDefaultSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Backward);
+                Program.GetSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Backward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;
@@ -373,7 +373,7 @@ namespace Sandra.UI.WF
             if (Game.IsLastMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                Program.GetDefaultSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Forward);
+                Program.GetSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Forward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;

--- a/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
+++ b/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
@@ -190,7 +190,9 @@ namespace Sandra.UI.WF
                         { SharedUIAction.ZoomIn, movesTextBox.TryZoomIn },
                         { SharedUIAction.ZoomOut, movesTextBox.TryZoomOut },
 
+                        { RichTextBoxBase.CutSelectionToClipBoard, movesTextBox.TryCutSelectionToClipBoard },
                         { RichTextBoxBase.CopySelectionToClipBoard, movesTextBox.TryCopySelectionToClipBoard },
+                        { RichTextBoxBase.PasteSelectionFromClipBoard, movesTextBox.TryPasteSelectionFromClipBoard },
                         { RichTextBoxBase.SelectAllText, movesTextBox.TrySelectAllText },
                     });
 

--- a/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
+++ b/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
@@ -190,8 +190,8 @@ namespace Sandra.UI.WF
                         { SharedUIAction.ZoomIn, movesTextBox.TryZoomIn },
                         { SharedUIAction.ZoomOut, movesTextBox.TryZoomOut },
 
-                        { MovesTextBox.CopySelectionToClipBoard, movesTextBox.TryCopySelectionToClipBoard },
-                        { MovesTextBox.SelectAllText, movesTextBox.TrySelectAllText },
+                        { RichTextBoxBase.CopySelectionToClipBoard, movesTextBox.TryCopySelectionToClipBoard },
+                        { RichTextBoxBase.SelectAllText, movesTextBox.TrySelectAllText },
                     });
 
                     UIMenu.AddTo(movesTextBox);

--- a/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
+++ b/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
@@ -286,7 +286,7 @@ namespace Sandra.UI.WF
             if (Game.IsFirstMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                Program.DefaultSettings.Settings.GetValue(SettingKeys.FastNavigationPlyCount).Times(Game.Backward);
+                Program.GetDefaultSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Backward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;
@@ -373,7 +373,7 @@ namespace Sandra.UI.WF
             if (Game.IsLastMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                Program.DefaultSettings.Settings.GetValue(SettingKeys.FastNavigationPlyCount).Times(Game.Forward);
+                Program.GetDefaultSetting(SettingKeys.FastNavigationPlyCount).Times(Game.Forward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;

--- a/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
+++ b/Sandra.UI.WF.Chess/InteractiveGame.UIActions.cs
@@ -286,7 +286,7 @@ namespace Sandra.UI.WF
             if (Game.IsFirstMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                OwnerForm.FastNavigationPlyCount.Times(Game.Backward);
+                Program.DefaultSettings.Settings.GetValue(SettingKeys.FastNavigationPlyCount).Times(Game.Backward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;
@@ -373,7 +373,7 @@ namespace Sandra.UI.WF
             if (Game.IsLastMove) return UIActionVisibility.Disabled;
             if (perform)
             {
-                OwnerForm.FastNavigationPlyCount.Times(Game.Forward);
+                Program.DefaultSettings.Settings.GetValue(SettingKeys.FastNavigationPlyCount).Times(Game.Forward);
                 ActiveMoveTreeUpdated();
             }
             return UIActionVisibility.Enabled;

--- a/Sandra.UI.WF.Chess/Localizers.cs
+++ b/Sandra.UI.WF.Chess/Localizers.cs
@@ -29,9 +29,11 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey CopyDiagramToClipboard = new LocalizedStringKey(nameof(CopyDiagramToClipboard));
         internal static readonly LocalizedStringKey DeleteLine = new LocalizedStringKey(nameof(DeleteLine));
         internal static readonly LocalizedStringKey DemoteLine = new LocalizedStringKey(nameof(DemoteLine));
+        internal static readonly LocalizedStringKey EditPreferencesFile = new LocalizedStringKey(nameof(EditPreferencesFile));
         internal static readonly LocalizedStringKey EndOfGame = new LocalizedStringKey(nameof(EndOfGame));
         internal static readonly LocalizedStringKey FastBackward = new LocalizedStringKey(nameof(FastBackward));
         internal static readonly LocalizedStringKey FastForward = new LocalizedStringKey(nameof(FastForward));
+        internal static readonly LocalizedStringKey File = new LocalizedStringKey(nameof(File));
         internal static readonly LocalizedStringKey FirstMove = new LocalizedStringKey(nameof(FirstMove));
         internal static readonly LocalizedStringKey FlipBoard = new LocalizedStringKey(nameof(FlipBoard));
         internal static readonly LocalizedStringKey Game = new LocalizedStringKey(nameof(Game));
@@ -168,8 +170,10 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.DeleteLine, "Delete line" },
                 { LocalizedStringKeys.DemoteLine, "Demote line" },
                 { LocalizedStringKeys.EndOfGame, "End of game" },
+                { LocalizedStringKeys.EditPreferencesFile, "Edit preferences" },
                 { LocalizedStringKeys.FastBackward, "Fast backward" },
                 { LocalizedStringKeys.FastForward, "Fast forward" },
+                { LocalizedStringKeys.File, "File" },
                 { LocalizedStringKeys.FirstMove, "First move" },
                 { LocalizedStringKeys.FlipBoard, "Flip board" },
                 { LocalizedStringKeys.Game, "Game" },
@@ -241,9 +245,11 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.CopyDiagramToClipboard, "Diagram naar klembord kopiëren" },
                 { LocalizedStringKeys.DeleteLine, "Variant verwijderen" },
                 { LocalizedStringKeys.DemoteLine, "Variant degraderen" },
+                { LocalizedStringKeys.EditPreferencesFile, "Wijzig voorkeuren" },
                 { LocalizedStringKeys.EndOfGame, "Naar einde partij" },
                 { LocalizedStringKeys.FastBackward, "Snel achterwaarts" },
                 { LocalizedStringKeys.FastForward, "Snel voorwaarts" },
+                { LocalizedStringKeys.File, "Bestand" },
                 { LocalizedStringKeys.FirstMove, "Eerste zet" },
                 { LocalizedStringKeys.FlipBoard, "Bord omkeren" },
                 { LocalizedStringKeys.Game, "Partij" },

--- a/Sandra.UI.WF.Chess/Localizers.cs
+++ b/Sandra.UI.WF.Chess/Localizers.cs
@@ -28,7 +28,6 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey Copy = new LocalizedStringKey(nameof(Copy));
         internal static readonly LocalizedStringKey CopyDiagramToClipboard = new LocalizedStringKey(nameof(CopyDiagramToClipboard));
         internal static readonly LocalizedStringKey Cut = new LocalizedStringKey(nameof(Cut));
-        internal static readonly LocalizedStringKey Paste = new LocalizedStringKey(nameof(Paste));
         internal static readonly LocalizedStringKey DeleteLine = new LocalizedStringKey(nameof(DeleteLine));
         internal static readonly LocalizedStringKey DemoteLine = new LocalizedStringKey(nameof(DemoteLine));
         internal static readonly LocalizedStringKey EditPreferencesFile = new LocalizedStringKey(nameof(EditPreferencesFile));
@@ -46,10 +45,12 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey NewGame = new LocalizedStringKey(nameof(NewGame));
         internal static readonly LocalizedStringKey NextLine = new LocalizedStringKey(nameof(NextLine));
         internal static readonly LocalizedStringKey NextMove = new LocalizedStringKey(nameof(NextMove));
+        internal static readonly LocalizedStringKey Paste = new LocalizedStringKey(nameof(Paste));
         internal static readonly LocalizedStringKey PieceSymbols = new LocalizedStringKey(nameof(PieceSymbols));
         internal static readonly LocalizedStringKey PreviousLine = new LocalizedStringKey(nameof(PreviousLine));
         internal static readonly LocalizedStringKey PreviousMove = new LocalizedStringKey(nameof(PreviousMove));
         internal static readonly LocalizedStringKey PromoteLine = new LocalizedStringKey(nameof(PromoteLine));
+        internal static readonly LocalizedStringKey Save = new LocalizedStringKey(nameof(Save));
         internal static readonly LocalizedStringKey SelectAll = new LocalizedStringKey(nameof(SelectAll));
         internal static readonly LocalizedStringKey ShowDefaultSettingsFile = new LocalizedStringKey(nameof(ShowDefaultSettingsFile));
         internal static readonly LocalizedStringKey StartOfGame = new LocalizedStringKey(nameof(StartOfGame));
@@ -194,6 +195,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.PreviousLine, "Previous line" },
                 { LocalizedStringKeys.PreviousMove, "Previous move" },
                 { LocalizedStringKeys.PromoteLine, "Promote line" },
+                { LocalizedStringKeys.Save, "Save" },
                 { LocalizedStringKeys.SelectAll, "Select All" },
                 { LocalizedStringKeys.ShowDefaultSettingsFile, "Show default settings" },
                 { LocalizedStringKeys.StartOfGame, "Start of game" },
@@ -274,6 +276,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.PreviousLine, "Vorige variant" },
                 { LocalizedStringKeys.PreviousMove, "Vorige zet" },
                 { LocalizedStringKeys.PromoteLine, "Variant promoveren" },
+                { LocalizedStringKeys.Save, "Opslaan" },
                 { LocalizedStringKeys.SelectAll, "Alles selecteren" },
                 { LocalizedStringKeys.ShowDefaultSettingsFile, "Standaard instellingen tonen" },
                 { LocalizedStringKeys.StartOfGame, "Naar begin partij" },

--- a/Sandra.UI.WF.Chess/Localizers.cs
+++ b/Sandra.UI.WF.Chess/Localizers.cs
@@ -31,6 +31,7 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey DemoteLine = new LocalizedStringKey(nameof(DemoteLine));
         internal static readonly LocalizedStringKey EditPreferencesFile = new LocalizedStringKey(nameof(EditPreferencesFile));
         internal static readonly LocalizedStringKey EndOfGame = new LocalizedStringKey(nameof(EndOfGame));
+        internal static readonly LocalizedStringKey Exit = new LocalizedStringKey(nameof(Exit));
         internal static readonly LocalizedStringKey FastBackward = new LocalizedStringKey(nameof(FastBackward));
         internal static readonly LocalizedStringKey FastForward = new LocalizedStringKey(nameof(FastForward));
         internal static readonly LocalizedStringKey File = new LocalizedStringKey(nameof(File));
@@ -170,6 +171,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.DeleteLine, "Delete line" },
                 { LocalizedStringKeys.DemoteLine, "Demote line" },
                 { LocalizedStringKeys.EndOfGame, "End of game" },
+                { LocalizedStringKeys.Exit, "Exit" },
                 { LocalizedStringKeys.EditPreferencesFile, "Edit preferences" },
                 { LocalizedStringKeys.FastBackward, "Fast backward" },
                 { LocalizedStringKeys.FastForward, "Fast forward" },
@@ -246,6 +248,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.DeleteLine, "Variant verwijderen" },
                 { LocalizedStringKeys.DemoteLine, "Variant degraderen" },
                 { LocalizedStringKeys.EditPreferencesFile, "Wijzig voorkeuren" },
+                { LocalizedStringKeys.Exit, "Afsluiten" },
                 { LocalizedStringKeys.EndOfGame, "Naar einde partij" },
                 { LocalizedStringKeys.FastBackward, "Snel achterwaarts" },
                 { LocalizedStringKeys.FastForward, "Snel voorwaarts" },

--- a/Sandra.UI.WF.Chess/Localizers.cs
+++ b/Sandra.UI.WF.Chess/Localizers.cs
@@ -27,6 +27,8 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey Chessboard = new LocalizedStringKey(nameof(Chessboard));
         internal static readonly LocalizedStringKey Copy = new LocalizedStringKey(nameof(Copy));
         internal static readonly LocalizedStringKey CopyDiagramToClipboard = new LocalizedStringKey(nameof(CopyDiagramToClipboard));
+        internal static readonly LocalizedStringKey Cut = new LocalizedStringKey(nameof(Cut));
+        internal static readonly LocalizedStringKey Paste = new LocalizedStringKey(nameof(Paste));
         internal static readonly LocalizedStringKey DeleteLine = new LocalizedStringKey(nameof(DeleteLine));
         internal static readonly LocalizedStringKey DemoteLine = new LocalizedStringKey(nameof(DemoteLine));
         internal static readonly LocalizedStringKey EditPreferencesFile = new LocalizedStringKey(nameof(EditPreferencesFile));
@@ -169,6 +171,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.Chessboard, "Chessboard" },
                 { LocalizedStringKeys.Copy, "Copy" },
                 { LocalizedStringKeys.CopyDiagramToClipboard, "Copy diagram to clipboard" },
+                { LocalizedStringKeys.Cut, "Cut" },
                 { LocalizedStringKeys.DeleteLine, "Delete line" },
                 { LocalizedStringKeys.DemoteLine, "Demote line" },
                 { LocalizedStringKeys.EndOfGame, "End of game" },
@@ -186,6 +189,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.NewGame, "New game" },
                 { LocalizedStringKeys.NextLine, "Next line" },
                 { LocalizedStringKeys.NextMove, "Next move" },
+                { LocalizedStringKeys.Paste, "Paste" },
                 { LocalizedStringKeys.PieceSymbols, "NBRQK" },
                 { LocalizedStringKeys.PreviousLine, "Previous line" },
                 { LocalizedStringKeys.PreviousMove, "Previous move" },
@@ -247,6 +251,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.Chessboard, "Schaakbord" },
                 { LocalizedStringKeys.Copy, "Kopiëren" },
                 { LocalizedStringKeys.CopyDiagramToClipboard, "Diagram naar klembord kopiëren" },
+                { LocalizedStringKeys.Cut, "Knippen" },
                 { LocalizedStringKeys.DeleteLine, "Variant verwijderen" },
                 { LocalizedStringKeys.DemoteLine, "Variant degraderen" },
                 { LocalizedStringKeys.EditPreferencesFile, "Wijzig voorkeuren" },
@@ -264,6 +269,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.NewGame, "Nieuwe partij" },
                 { LocalizedStringKeys.NextLine, "Volgende variant" },
                 { LocalizedStringKeys.NextMove, "Volgende zet" },
+                { LocalizedStringKeys.Paste, "Plakken" },
                 { LocalizedStringKeys.PieceSymbols, "PLTDK" },
                 { LocalizedStringKeys.PreviousLine, "Vorige variant" },
                 { LocalizedStringKeys.PreviousMove, "Vorige zet" },

--- a/Sandra.UI.WF.Chess/Localizers.cs
+++ b/Sandra.UI.WF.Chess/Localizers.cs
@@ -49,6 +49,7 @@ namespace Sandra.UI.WF
         internal static readonly LocalizedStringKey PreviousMove = new LocalizedStringKey(nameof(PreviousMove));
         internal static readonly LocalizedStringKey PromoteLine = new LocalizedStringKey(nameof(PromoteLine));
         internal static readonly LocalizedStringKey SelectAll = new LocalizedStringKey(nameof(SelectAll));
+        internal static readonly LocalizedStringKey ShowDefaultSettingsFile = new LocalizedStringKey(nameof(ShowDefaultSettingsFile));
         internal static readonly LocalizedStringKey StartOfGame = new LocalizedStringKey(nameof(StartOfGame));
         internal static readonly LocalizedStringKey UseLongAlgebraicNotation = new LocalizedStringKey(nameof(UseLongAlgebraicNotation));
         internal static readonly LocalizedStringKey UsePGNPieceSymbols = new LocalizedStringKey(nameof(UsePGNPieceSymbols));
@@ -190,6 +191,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.PreviousMove, "Previous move" },
                 { LocalizedStringKeys.PromoteLine, "Promote line" },
                 { LocalizedStringKeys.SelectAll, "Select All" },
+                { LocalizedStringKeys.ShowDefaultSettingsFile, "Show default settings" },
                 { LocalizedStringKeys.StartOfGame, "Start of game" },
                 { LocalizedStringKeys.UseLongAlgebraicNotation, "Use long algebraic notation" },
                 { LocalizedStringKeys.UsePGNPieceSymbols, "Use PGN notation" },
@@ -267,6 +269,7 @@ namespace Sandra.UI.WF
                 { LocalizedStringKeys.PreviousMove, "Vorige zet" },
                 { LocalizedStringKeys.PromoteLine, "Variant promoveren" },
                 { LocalizedStringKeys.SelectAll, "Alles selecteren" },
+                { LocalizedStringKeys.ShowDefaultSettingsFile, "Standaard instellingen tonen" },
                 { LocalizedStringKeys.StartOfGame, "Naar begin partij" },
                 { LocalizedStringKeys.UseLongAlgebraicNotation, "Lange notatie gebruiken" },
                 { LocalizedStringKeys.UsePGNPieceSymbols, "PGN notatie gebruiken" },

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -121,7 +121,7 @@ namespace Sandra.UI.WF
 
                     UIMenu.AddTo(settingsTextBox);
 
-                    openDefaultSettingsForm = new Form()
+                    openDefaultSettingsForm = new UIActionForm()
                     {
                         Owner = this,
                         ClientSize = new Size(600, 600),

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -108,6 +108,14 @@ namespace Sandra.UI.WF
                         ReadOnly = true,
                     };
 
+                    settingsTextBox.BindActions(new UIActionBindings
+                    {
+                        { RichTextBoxBase.CopySelectionToClipBoard, settingsTextBox.TryCopySelectionToClipBoard },
+                        { RichTextBoxBase.SelectAllText, settingsTextBox.TrySelectAllText },
+                    });
+
+                    UIMenu.AddTo(settingsTextBox);
+
                     openDefaultSettingsForm = new Form()
                     {
                         Owner = this,

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -53,6 +53,16 @@ namespace Sandra.UI.WF
 
         public UIActionState TryEditPreferencesFile(bool perform)
         {
+            if (perform)
+            {
+                // Before opening the possibly non-existent file, write to it.
+                // This pretty-prints it too.
+                Program.LocalSettings.WriteToFile();
+                using (var process = System.Diagnostics.Process.Start(
+                    "notepad.exe",
+                    Program.LocalSettings.AbsoluteFilePath)) ;
+            }
+
             return UIActionVisibility.Enabled;
         }
 

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -56,14 +56,13 @@ namespace Sandra.UI.WF
 
         private Form CreateSettingsForm(bool isReadOnly, SettingsFile settingsFile)
         {
-            var settingsTextBox = new SettingsTextBox()
+            var settingsTextBox = new SettingsTextBox(settingsFile)
             {
                 Dock = DockStyle.Fill,
                 BorderStyle = BorderStyle.None,
                 BackColor = Color.White,
                 ForeColor = Color.Black,
                 Font = new Font("Consolas", 10),
-                Text = File.ReadAllText(settingsFile.AbsoluteFilePath),
                 ReadOnly = isReadOnly,
                 WordWrap = false,
                 ScrollBars = RichTextBoxScrollBars.Both,

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -1,0 +1,45 @@
+﻿/*********************************************************************************
+ * MdiContainerForm.UIActions.cs
+ * 
+ * Copyright (c) 2004-2018 Henk Nicolai
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * 
+ *********************************************************************************/
+using System;
+
+namespace Sandra.UI.WF
+{
+    /// <summary>
+    /// Main MdiContainer Form.
+    /// </summary>
+    public partial class MdiContainerForm
+    {
+        public const string MdiContainerFormUIActionPrefix = nameof(MdiContainerForm) + ".";
+
+        public static readonly DefaultUIActionBinding OpenNewPlayingBoard = new DefaultUIActionBinding(
+            new UIAction(MdiContainerFormUIActionPrefix + nameof(OpenNewPlayingBoard)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                MenuCaptionKey = LocalizedStringKeys.NewGame,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.N), },
+            });
+
+        public UIActionState TryOpenNewPlayingBoard(bool perform)
+        {
+            if (perform) NewPlayingBoard();
+            return UIActionVisibility.Enabled;
+        }
+    }
+}

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -112,6 +112,9 @@ namespace Sandra.UI.WF
 
                     settingsTextBox.BindActions(new UIActionBindings
                     {
+                        { SharedUIAction.ZoomIn, settingsTextBox.TryZoomIn },
+                        { SharedUIAction.ZoomOut, settingsTextBox.TryZoomOut },
+
                         { RichTextBoxBase.CopySelectionToClipBoard, settingsTextBox.TryCopySelectionToClipBoard },
                         { RichTextBoxBase.SelectAllText, settingsTextBox.TrySelectAllText },
                     });

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -74,7 +74,9 @@ namespace Sandra.UI.WF
                 { SharedUIAction.ZoomIn, settingsTextBox.TryZoomIn },
                 { SharedUIAction.ZoomOut, settingsTextBox.TryZoomOut },
 
+                { RichTextBoxBase.CutSelectionToClipBoard, settingsTextBox.TryCutSelectionToClipBoard },
                 { RichTextBoxBase.CopySelectionToClipBoard, settingsTextBox.TryCopySelectionToClipBoard },
+                { RichTextBoxBase.PasteSelectionFromClipBoard, settingsTextBox.TryPasteSelectionFromClipBoard },
                 { RichTextBoxBase.SelectAllText, settingsTextBox.TrySelectAllText },
             });
 

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -71,6 +71,8 @@ namespace Sandra.UI.WF
 
             settingsTextBox.BindActions(new UIActionBindings
             {
+                { SettingsTextBox.SaveToFile, settingsTextBox.TrySaveToFile },
+
                 { SharedUIAction.ZoomIn, settingsTextBox.TryZoomIn },
                 { SharedUIAction.ZoomOut, settingsTextBox.TryZoomOut },
 

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -106,6 +106,8 @@ namespace Sandra.UI.WF
                         Font = new Font("Consolas", 10),
                         Text = File.ReadAllText(Program.DefaultSettings.AbsoluteFilePath),
                         ReadOnly = true,
+                        WordWrap = false,
+                        ScrollBars = RichTextBoxScrollBars.Both,
                     };
 
                     settingsTextBox.BindActions(new UIActionBindings

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -27,6 +27,22 @@ namespace Sandra.UI.WF
     {
         public const string MdiContainerFormUIActionPrefix = nameof(MdiContainerForm) + ".";
 
+        public static readonly DefaultUIActionBinding Exit = new DefaultUIActionBinding(
+            new UIAction(MdiContainerFormUIActionPrefix + nameof(Exit)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                IsFirstInGroup = true,
+                MenuCaptionKey = LocalizedStringKeys.Exit,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Alt, ConsoleKey.F4), },
+            });
+
+        public UIActionState TryExit(bool perform)
+        {
+            if (perform) Close();
+            return UIActionVisibility.Enabled;
+        }
+
         public static readonly DefaultUIActionBinding EditPreferencesFile = new DefaultUIActionBinding(
             new UIAction(MdiContainerFormUIActionPrefix + nameof(EditPreferencesFile)),
             new UIActionBinding()

--- a/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.UIActions.cs
@@ -27,6 +27,19 @@ namespace Sandra.UI.WF
     {
         public const string MdiContainerFormUIActionPrefix = nameof(MdiContainerForm) + ".";
 
+        public static readonly DefaultUIActionBinding EditPreferencesFile = new DefaultUIActionBinding(
+            new UIAction(MdiContainerFormUIActionPrefix + nameof(EditPreferencesFile)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                MenuCaptionKey = LocalizedStringKeys.EditPreferencesFile,
+            });
+
+        public UIActionState TryEditPreferencesFile(bool perform)
+        {
+            return UIActionVisibility.Enabled;
+        }
+
         public static readonly DefaultUIActionBinding OpenNewPlayingBoard = new DefaultUIActionBinding(
             new UIAction(MdiContainerFormUIActionPrefix + nameof(OpenNewPlayingBoard)),
             new UIActionBinding()

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -144,7 +144,16 @@ namespace Sandra.UI.WF
                 bindFocusDependentUIActions(langMenu, Localizers.Registered.Select(x => x.SwitchToLangUIActionBinding).ToArray());
             }
 
+            // Actions which have their handler in this instance.
+            this.BindAction(EditPreferencesFile, TryEditPreferencesFile);
             this.BindAction(OpenNewPlayingBoard, TryOpenNewPlayingBoard);
+
+            UIMenuNode.Container fileMenu = new UIMenuNode.Container(LocalizedStringKeys.File);
+            mainMenuActionHandler.RootMenuNode.Nodes.Add(fileMenu);
+
+            // Add these actions to the "Game" dropdown list.
+            bindFocusDependentUIActions(fileMenu,
+                                        EditPreferencesFile);
 
             UIMenuNode.Container gameMenu = new UIMenuNode.Container(LocalizedStringKeys.Game);
             mainMenuActionHandler.RootMenuNode.Nodes.Add(gameMenu);

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -146,6 +146,7 @@ namespace Sandra.UI.WF
 
             // Actions which have their handler in this instance.
             this.BindAction(EditPreferencesFile, TryEditPreferencesFile);
+            this.BindAction(Exit, TryExit);
             this.BindAction(OpenNewPlayingBoard, TryOpenNewPlayingBoard);
 
             UIMenuNode.Container fileMenu = new UIMenuNode.Container(LocalizedStringKeys.File);
@@ -153,7 +154,8 @@ namespace Sandra.UI.WF
 
             // Add these actions to the "Game" dropdown list.
             bindFocusDependentUIActions(fileMenu,
-                                        EditPreferencesFile);
+                                        EditPreferencesFile,
+                                        Exit);
 
             UIMenuNode.Container gameMenu = new UIMenuNode.Container(LocalizedStringKeys.Game);
             mainMenuActionHandler.RootMenuNode.Nodes.Add(gameMenu);

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -35,6 +35,7 @@ namespace Sandra.UI.WF
 
         private PersistableFormState formState;
 
+        private Form openLocalSettingsForm;
         private Form openDefaultSettingsForm;
 
         public MdiContainerForm()

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -35,6 +35,8 @@ namespace Sandra.UI.WF
 
         private PersistableFormState formState;
 
+        private Form openDefaultSettingsForm;
+
         public MdiContainerForm()
         {
             IsMdiContainer = true;
@@ -146,6 +148,7 @@ namespace Sandra.UI.WF
 
             // Actions which have their handler in this instance.
             this.BindAction(EditPreferencesFile, TryEditPreferencesFile);
+            this.BindAction(ShowDefaultSettingsFile, TryShowDefaultSettingsFile);
             this.BindAction(Exit, TryExit);
             this.BindAction(OpenNewPlayingBoard, TryOpenNewPlayingBoard);
 
@@ -155,6 +158,7 @@ namespace Sandra.UI.WF
             // Add these actions to the "Game" dropdown list.
             bindFocusDependentUIActions(fileMenu,
                                         EditPreferencesFile,
+                                        ShowDefaultSettingsFile,
                                         Exit);
 
             UIMenuNode.Container gameMenu = new UIMenuNode.Container(LocalizedStringKeys.Game);

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -29,7 +29,7 @@ namespace Sandra.UI.WF
     /// <summary>
     /// Main MdiContainer Form.
     /// </summary>
-    public class MdiContainerForm : Form, IUIActionHandlerProvider
+    public partial class MdiContainerForm : Form, IUIActionHandlerProvider
     {
         public EnumIndexedArray<ColoredPiece, Image> PieceImages { get; private set; }
 
@@ -59,23 +59,6 @@ namespace Sandra.UI.WF
 
         // Separate action handler for building the MainMenuStrip.
         readonly UIActionHandler mainMenuActionHandler = new UIActionHandler();
-
-        public const string MdiContainerFormUIActionPrefix = nameof(MdiContainerForm) + ".";
-
-        public static readonly DefaultUIActionBinding OpenNewPlayingBoard = new DefaultUIActionBinding(
-            new UIAction(MdiContainerFormUIActionPrefix + nameof(OpenNewPlayingBoard)),
-            new UIActionBinding()
-            {
-                ShowInMenu = true,
-                MenuCaptionKey = LocalizedStringKeys.NewGame,
-                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.N), },
-            });
-
-        public UIActionState TryOpenNewPlayingBoard(bool perform)
-        {
-            if (perform) NewPlayingBoard();
-            return UIActionVisibility.Enabled;
-        }
 
         class FocusDependentUIActionState
         {

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -320,7 +320,7 @@ namespace Sandra.UI.WF
 
             // Initialize from settings if available.
             bool boundsInitialized = false;
-            if (Program.AutoSave.CurrentSettings.TryGetValue(SettingKeys.Window, out formState))
+            if (Program.TryGetAutoSaveValue(SettingKeys.Window, out formState))
             {
                 Rectangle targetBounds = formState.Bounds;
 

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -33,11 +33,6 @@ namespace Sandra.UI.WF
     {
         public EnumIndexedArray<ColoredPiece, Image> PieceImages { get; private set; }
 
-        /// <summary>
-        /// Contains the number of plies to move forward of backward in a game for fast navigation.
-        /// </summary>
-        public int FastNavigationPlyCount { get; private set; }
-
         private PersistableFormState formState;
 
         public MdiContainerForm()
@@ -365,9 +360,6 @@ namespace Sandra.UI.WF
 
             // Load chess piece images from a fixed path.
             PieceImages = loadChessPieceImages();
-
-            // 10 plies == 5 moves.
-            FastNavigationPlyCount = 10;
 
             NewPlayingBoard();
         }

--- a/Sandra.UI.WF.Chess/MdiContainerForm.cs
+++ b/Sandra.UI.WF.Chess/MdiContainerForm.cs
@@ -29,7 +29,7 @@ namespace Sandra.UI.WF
     /// <summary>
     /// Main MdiContainer Form.
     /// </summary>
-    public partial class MdiContainerForm : Form, IUIActionHandlerProvider
+    public partial class MdiContainerForm : UIActionForm
     {
         public EnumIndexedArray<ColoredPiece, Image> PieceImages { get; private set; }
 
@@ -53,11 +53,6 @@ namespace Sandra.UI.WF
             // After building the MainMenuStrip, build an index of ToolstripMenuItems which are bound on focus dependent UIActions.
             indexFocusDependentUIActions(MainMenuStrip.Items);
         }
-
-        /// <summary>
-        /// Gets the action handler for this control.
-        /// </summary>
-        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
 
         // Separate action handler for building the MainMenuStrip.
         readonly UIActionHandler mainMenuActionHandler = new UIActionHandler();
@@ -282,20 +277,6 @@ namespace Sandra.UI.WF
             }
 
             updateFocusDependentMenuItems();
-        }
-
-        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
-        {
-            try
-            {
-                // This code makes shortcuts work for all UIActionHandlers.
-                return KeyUtils.TryExecute(keyData) || base.ProcessCmdKey(ref msg, keyData);
-            }
-            catch (Exception e)
-            {
-                MessageBox.Show(e.Message);
-                return true;
-            }
         }
 
         public void NewPlayingBoard()

--- a/Sandra.UI.WF.Chess/MovesTextBox.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.UIActions.cs
@@ -68,31 +68,5 @@ namespace Sandra.UI.WF
 
             return new UIActionState(UIActionVisibility.Enabled, moveFormattingOption == MoveFormattingOption.UseLocalizedLongAlgebraic);
         }
-
-        public UIActionState TryZoomIn(bool perform)
-        {
-            int zoomFactor = PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor);
-            if (zoomFactor >= PType.RichTextZoomFactor.MaxDiscreteValue) return UIActionVisibility.Disabled;
-            if (perform)
-            {
-                zoomFactor++;
-                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
-                autoSaveZoomFactor(zoomFactor);
-            }
-            return UIActionVisibility.Enabled;
-        }
-
-        public UIActionState TryZoomOut(bool perform)
-        {
-            int zoomFactor = PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor);
-            if (zoomFactor <= PType.RichTextZoomFactor.MinDiscreteValue) return UIActionVisibility.Disabled;
-            if (perform)
-            {
-                zoomFactor--;
-                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
-                autoSaveZoomFactor(zoomFactor);
-            }
-            return UIActionVisibility.Enabled;
-        }
     }
 }

--- a/Sandra.UI.WF.Chess/MovesTextBox.UIActions.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.UIActions.cs
@@ -16,8 +16,6 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
-using System;
-
 namespace Sandra.UI.WF
 {
     public partial class MovesTextBox
@@ -69,40 +67,6 @@ namespace Sandra.UI.WF
             }
 
             return new UIActionState(UIActionVisibility.Enabled, moveFormattingOption == MoveFormattingOption.UseLocalizedLongAlgebraic);
-        }
-
-        public static readonly DefaultUIActionBinding CopySelectionToClipBoard = new DefaultUIActionBinding(
-            new UIAction(MovesTextBoxUIActionPrefix + nameof(CopySelectionToClipBoard)),
-            new UIActionBinding()
-            {
-                ShowInMenu = true,
-                IsFirstInGroup = true,
-                MenuCaptionKey = LocalizedStringKeys.Copy,
-                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.C), },
-            });
-
-        public UIActionState TryCopySelectionToClipBoard(bool perform)
-        {
-            if (SelectionLength == 0) return UIActionVisibility.Disabled;
-            if (perform) Copy();
-            return UIActionVisibility.Enabled;
-        }
-
-        public static readonly DefaultUIActionBinding SelectAllText = new DefaultUIActionBinding(
-            new UIAction(MovesTextBoxUIActionPrefix + nameof(SelectAllText)),
-            new UIActionBinding()
-            {
-                ShowInMenu = true,
-                IsFirstInGroup = true,
-                MenuCaptionKey = LocalizedStringKeys.SelectAll,
-                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.A), },
-            });
-
-        public UIActionState TrySelectAllText(bool perform)
-        {
-            if (TextLength == 0) return UIActionVisibility.Disabled;
-            if (perform) SelectAll();
-            return UIActionVisibility.Enabled;
         }
 
         public UIActionState TryZoomIn(bool perform)

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -73,7 +73,7 @@ namespace Sandra.UI.WF
             applyDefaultStyle();
 
             int zoomFactor;
-            if (Program.AutoSave.CurrentSettings.TryGetValue(SettingKeys.Zoom, out zoomFactor))
+            if (Program.TryGetAutoSaveValue(SettingKeys.Zoom, out zoomFactor))
             {
                 ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
             }
@@ -162,7 +162,7 @@ namespace Sandra.UI.WF
             {
                 // Initialize moveFormattingOption from settings.
                 MFOSettingValue mfoSettingValue;
-                if (Program.AutoSave.CurrentSettings.TryGetValue(SettingKeys.Notation, out mfoSettingValue))
+                if (Program.TryGetAutoSaveValue(SettingKeys.Notation, out mfoSettingValue))
                 {
                     moveFormattingOption = (MoveFormattingOption)mfoSettingValue;
                 }

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -30,7 +30,7 @@ namespace Sandra.UI.WF
     /// <summary>
     /// Represents a read-only Windows rich text box which displays a list of chess moves.
     /// </summary>
-    public partial class MovesTextBox : UpdatableRichTextBox, IUIActionHandlerProvider
+    public partial class MovesTextBox : RichTextBoxBase
     {
         private sealed class TextElementStyle
         {
@@ -124,11 +124,6 @@ namespace Sandra.UI.WF
             }
             base.Dispose(disposing);
         }
-
-        /// <summary>
-        /// Gets the action handler for this control.
-        /// </summary>
-        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
 
         /// <summary>
         /// Standardized PGN notation for pieces.

--- a/Sandra.UI.WF.Chess/MovesTextBox.cs
+++ b/Sandra.UI.WF.Chess/MovesTextBox.cs
@@ -72,12 +72,6 @@ namespace Sandra.UI.WF
 
             applyDefaultStyle();
 
-            int zoomFactor;
-            if (Program.TryGetAutoSaveValue(SettingKeys.Zoom, out zoomFactor))
-            {
-                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
-            }
-
             // DisplayTextChanged handlers are called immediately upon registration.
             // This initializes moveFormatter.
             localizedPieceSymbols.DisplayText.ValueChanged += _ =>
@@ -452,17 +446,6 @@ namespace Sandra.UI.WF
             }
 
             base.OnMouseWheel(e);
-
-            if (ModifierKeys.HasFlag(Keys.Control))
-            {
-                // ZoomFactor isn't updated yet, so predict here what it's going to be.
-                autoSaveZoomFactor(PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor) + Math.Sign(e.Delta));
-            }
-        }
-
-        private void autoSaveZoomFactor(int zoomFactor)
-        {
-            Program.AutoSave.Persist(SettingKeys.Zoom, zoomFactor);
         }
     }
 }

--- a/Sandra.UI.WF.Chess/Program.cs
+++ b/Sandra.UI.WF.Chess/Program.cs
@@ -102,6 +102,9 @@ namespace Sandra.UI.WF
         internal static TValue GetDefaultSetting<TValue>(SettingProperty<TValue> property)
             => DefaultSettings.Settings.GetValue(property);
 
+        internal static TValue GetSetting<TValue>(SettingProperty<TValue> property)
+            => LocalSettings.Settings.GetValue(property);
+
         internal static bool TryGetAutoSaveValue<TValue>(SettingProperty<TValue> property, out TValue value)
             => AutoSave.CurrentSettings.TryGetValue(property, out value);
 

--- a/Sandra.UI.WF.Chess/Program.cs
+++ b/Sandra.UI.WF.Chess/Program.cs
@@ -53,7 +53,7 @@ namespace Sandra.UI.WF
 
             Localizers.Register(new EnglishLocalizer(), new DutchLocalizer());
 
-            string appDataSubFolderName = DefaultSettings.Settings.GetValue(SettingKeys.AppDataSubFolderName);
+            string appDataSubFolderName = GetDefaultSetting(SettingKeys.AppDataSubFolderName);
             AutoSave = new AutoSave(appDataSubFolderName, new SettingCopy(Settings.AutoSaveSchema));
 
             Chess.Constants.ForceInitialize();
@@ -71,6 +71,9 @@ namespace Sandra.UI.WF
             // Wait until the auto-save background task has finished.
             AutoSave.Close();
         }
+
+        internal static TValue GetDefaultSetting<TValue>(SettingProperty<TValue> property)
+            => DefaultSettings.Settings.GetValue(property);
 
         internal static Image LoadImage(string imageFileKey)
         {

--- a/Sandra.UI.WF.Chess/Program.cs
+++ b/Sandra.UI.WF.Chess/Program.cs
@@ -18,8 +18,10 @@
  *********************************************************************************/
 using SysExtensions;
 using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace Sandra.UI.WF
@@ -48,8 +50,8 @@ namespace Sandra.UI.WF
                 Path.Combine(ExecutableFolder, DefaultSettingsFileName),
                 Settings.CreateBuiltIn());
 
-            // Uncomment to generate Default.settings in the Bin directory.
-            //DefaultSettings.WriteToFile();
+            // In debug mode, make sure that DefaultSettings.json matches what's read from the file.
+            WriteToSourceDefaultSettingFile();
 
             Localizers.Register(new EnglishLocalizer(), new DutchLocalizer());
 
@@ -89,6 +91,17 @@ namespace Sandra.UI.WF
                 exc.Trace();
                 return null;
             }
+        }
+
+        [Conditional("DEBUG")]
+        private static void WriteToSourceDefaultSettingFile()
+        {
+            DirectoryInfo exeDir = new DirectoryInfo(ExecutableFolder);
+            DirectoryInfo devDir = exeDir.Parent.GetDirectories("Sandra.UI.WF.Chess", SearchOption.TopDirectoryOnly).First();
+
+#if DEBUG
+            DefaultSettings.WriteToFile(Path.Combine(devDir.FullName, "DefaultSettings.json"));
+#endif
         }
     }
 }

--- a/Sandra.UI.WF.Chess/Program.cs
+++ b/Sandra.UI.WF.Chess/Program.cs
@@ -59,7 +59,7 @@ namespace Sandra.UI.WF
             Chess.Constants.ForceInitialize();
 
             Localizer localizer;
-            if (AutoSave.CurrentSettings.TryGetValue(Localizers.LangSetting, out localizer))
+            if (TryGetAutoSaveValue(Localizers.LangSetting, out localizer))
             {
                 Localizer.Current = localizer;
             }
@@ -74,6 +74,9 @@ namespace Sandra.UI.WF
 
         internal static TValue GetDefaultSetting<TValue>(SettingProperty<TValue> property)
             => DefaultSettings.Settings.GetValue(property);
+
+        internal static bool TryGetAutoSaveValue<TValue>(SettingProperty<TValue> property, out TValue value)
+            => AutoSave.CurrentSettings.TryGetValue(property, out value);
 
         internal static Image LoadImage(string imageFileKey)
         {

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
@@ -57,5 +57,31 @@ namespace Sandra.UI.WF
             if (perform) SelectAll();
             return UIActionVisibility.Enabled;
         }
+
+        public UIActionState TryZoomIn(bool perform)
+        {
+            int zoomFactor = PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor);
+            if (zoomFactor >= PType.RichTextZoomFactor.MaxDiscreteValue) return UIActionVisibility.Disabled;
+            if (perform)
+            {
+                zoomFactor++;
+                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
+                autoSaveZoomFactor(zoomFactor);
+            }
+            return UIActionVisibility.Enabled;
+        }
+
+        public UIActionState TryZoomOut(bool perform)
+        {
+            int zoomFactor = PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor);
+            if (zoomFactor <= PType.RichTextZoomFactor.MinDiscreteValue) return UIActionVisibility.Disabled;
+            if (perform)
+            {
+                zoomFactor--;
+                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
+                autoSaveZoomFactor(zoomFactor);
+            }
+            return UIActionVisibility.Enabled;
+        }
     }
 }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
@@ -16,9 +16,46 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
+using System;
+
 namespace Sandra.UI.WF
 {
     public partial class RichTextBoxBase
     {
+        public const string RichTextBoxBaseUIActionPrefix = nameof(RichTextBoxBase) + ".";
+
+        public static readonly DefaultUIActionBinding CopySelectionToClipBoard = new DefaultUIActionBinding(
+            new UIAction(RichTextBoxBaseUIActionPrefix + nameof(CopySelectionToClipBoard)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                IsFirstInGroup = true,
+                MenuCaptionKey = LocalizedStringKeys.Copy,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.C), },
+            });
+
+        public UIActionState TryCopySelectionToClipBoard(bool perform)
+        {
+            if (SelectionLength == 0) return UIActionVisibility.Disabled;
+            if (perform) Copy();
+            return UIActionVisibility.Enabled;
+        }
+
+        public static readonly DefaultUIActionBinding SelectAllText = new DefaultUIActionBinding(
+            new UIAction(RichTextBoxBaseUIActionPrefix + nameof(SelectAllText)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                IsFirstInGroup = true,
+                MenuCaptionKey = LocalizedStringKeys.SelectAll,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.A), },
+            });
+
+        public UIActionState TrySelectAllText(bool perform)
+        {
+            if (TextLength == 0) return UIActionVisibility.Disabled;
+            if (perform) SelectAll();
+            return UIActionVisibility.Enabled;
+        }
     }
 }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
@@ -17,6 +17,7 @@
  * 
  *********************************************************************************/
 using System;
+using System.Windows.Forms;
 
 namespace Sandra.UI.WF
 {
@@ -70,6 +71,7 @@ namespace Sandra.UI.WF
         public UIActionState TryPasteSelectionFromClipBoard(bool perform)
         {
             if (ReadOnly) return UIActionVisibility.Hidden;
+            if (!Clipboard.ContainsText()) return UIActionVisibility.Disabled;
             if (perform) Paste();
             return UIActionVisibility.Enabled;
         }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
@@ -24,12 +24,29 @@ namespace Sandra.UI.WF
     {
         public const string RichTextBoxBaseUIActionPrefix = nameof(RichTextBoxBase) + ".";
 
+        public static readonly DefaultUIActionBinding CutSelectionToClipBoard = new DefaultUIActionBinding(
+            new UIAction(RichTextBoxBaseUIActionPrefix + nameof(CutSelectionToClipBoard)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                IsFirstInGroup = true,
+                MenuCaptionKey = LocalizedStringKeys.Cut,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.X), },
+            });
+
+        public UIActionState TryCutSelectionToClipBoard(bool perform)
+        {
+            if (ReadOnly) return UIActionVisibility.Hidden;
+            if (SelectionLength == 0) return UIActionVisibility.Disabled;
+            if (perform) Cut();
+            return UIActionVisibility.Enabled;
+        }
+
         public static readonly DefaultUIActionBinding CopySelectionToClipBoard = new DefaultUIActionBinding(
             new UIAction(RichTextBoxBaseUIActionPrefix + nameof(CopySelectionToClipBoard)),
             new UIActionBinding()
             {
                 ShowInMenu = true,
-                IsFirstInGroup = true,
                 MenuCaptionKey = LocalizedStringKeys.Copy,
                 Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.C), },
             });
@@ -38,6 +55,22 @@ namespace Sandra.UI.WF
         {
             if (SelectionLength == 0) return UIActionVisibility.Disabled;
             if (perform) Copy();
+            return UIActionVisibility.Enabled;
+        }
+
+        public static readonly DefaultUIActionBinding PasteSelectionFromClipBoard = new DefaultUIActionBinding(
+            new UIAction(RichTextBoxBaseUIActionPrefix + nameof(PasteSelectionFromClipBoard)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                MenuCaptionKey = LocalizedStringKeys.Paste,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.V), },
+            });
+
+        public UIActionState TryPasteSelectionFromClipBoard(bool perform)
+        {
+            if (ReadOnly) return UIActionVisibility.Hidden;
+            if (perform) Paste();
             return UIActionVisibility.Enabled;
         }
 

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.UIActions.cs
@@ -1,5 +1,5 @@
 ﻿/*********************************************************************************
- * RichTextBoxBase.cs
+ * RichTextBoxBase.UIActions.cs
  * 
  * Copyright (c) 2004-2018 Henk Nicolai
  * 
@@ -18,18 +18,7 @@
  *********************************************************************************/
 namespace Sandra.UI.WF
 {
-    /// <summary>
-    /// Represents a read-only Windows rich text box which displays a json settings file.
-    /// </summary>
-    public partial class RichTextBoxBase : UpdatableRichTextBox, IUIActionHandlerProvider
+    public partial class RichTextBoxBase
     {
-        public RichTextBoxBase()
-        {
-        }
-
-        /// <summary>
-        /// Gets the action handler for this control.
-        /// </summary>
-        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
     }
 }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.cs
@@ -1,5 +1,5 @@
 ﻿/*********************************************************************************
- * SettingsTextBox.cs
+ * RichTextBoxBase.cs
  * 
  * Copyright (c) 2004-2018 Henk Nicolai
  * 
@@ -21,7 +21,15 @@ namespace Sandra.UI.WF
     /// <summary>
     /// Represents a read-only Windows rich text box which displays a json settings file.
     /// </summary>
-    public class SettingsTextBox : RichTextBoxBase
+    public class RichTextBoxBase : UpdatableRichTextBox, IUIActionHandlerProvider
     {
+        public RichTextBoxBase()
+        {
+        }
+
+        /// <summary>
+        /// Gets the action handler for this control.
+        /// </summary>
+        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
     }
 }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.cs
@@ -16,6 +16,9 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
+using System;
+using System.Windows.Forms;
+
 namespace Sandra.UI.WF
 {
     /// <summary>
@@ -25,11 +28,32 @@ namespace Sandra.UI.WF
     {
         public RichTextBoxBase()
         {
+            int zoomFactor;
+            if (Program.TryGetAutoSaveValue(SettingKeys.Zoom, out zoomFactor))
+            {
+                ZoomFactor = PType.RichTextZoomFactor.FromDiscreteZoomFactor(zoomFactor);
+            }
         }
 
         /// <summary>
         /// Gets the action handler for this control.
         /// </summary>
         public UIActionHandler ActionHandler { get; } = new UIActionHandler();
+
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            base.OnMouseWheel(e);
+
+            if (ModifierKeys.HasFlag(Keys.Control))
+            {
+                // ZoomFactor isn't updated yet, so predict here what it's going to be.
+                autoSaveZoomFactor(PType.RichTextZoomFactor.ToDiscreteZoomFactor(ZoomFactor) + Math.Sign(e.Delta));
+            }
+        }
+
+        private void autoSaveZoomFactor(int zoomFactor)
+        {
+            Program.AutoSave.Persist(SettingKeys.Zoom, zoomFactor);
+        }
     }
 }

--- a/Sandra.UI.WF.Chess/RichTextBoxBase.cs
+++ b/Sandra.UI.WF.Chess/RichTextBoxBase.cs
@@ -22,7 +22,8 @@ using System.Windows.Forms;
 namespace Sandra.UI.WF
 {
     /// <summary>
-    /// Represents a read-only Windows rich text box which displays a json settings file.
+    /// Represents a Windows rich text box with a number of applicatio-wide features
+    /// such as <see cref="UIAction"/> hooks and a mouse-wheel event handler.
     /// </summary>
     public partial class RichTextBoxBase : UpdatableRichTextBox, IUIActionHandlerProvider
     {

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -73,6 +73,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="RichTextBoxBase.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Settings.cs" />
     <Compile Include="SettingsTextBox.cs">
       <SubType>Component</SubType>

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -76,6 +76,10 @@
     <Compile Include="RichTextBoxBase.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="RichTextBoxBase.UIActions.cs">
+      <DependentUpon>RichTextBoxBase.cs</DependentUpon>
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Settings.cs" />
     <Compile Include="SettingsTextBox.cs">
       <SubType>Component</SubType>

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -55,6 +55,10 @@
     <Compile Include="MdiContainerForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="MdiContainerForm.UIActions.cs">
+      <DependentUpon>MdiContainerForm.cs</DependentUpon>
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="MovesTextBox.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -74,6 +74,9 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Settings.cs" />
+    <Compile Include="SettingsTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SharedUIAction.cs" />
     <Compile Include="StandardChessBoardForm.cs">
       <SubType>Form</SubType>

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -92,6 +92,9 @@
       <DependentUpon>StandardChessBoardForm.cs</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UIActionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sandra.Chess\Sandra.Chess.csproj">

--- a/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
+++ b/Sandra.UI.WF.Chess/Sandra.UI.WF.Chess.csproj
@@ -84,6 +84,10 @@
     <Compile Include="SettingsTextBox.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="SettingsTextBox.UIActions.cs">
+      <DependentUpon>SettingsTextBox.cs</DependentUpon>
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SharedUIAction.cs" />
     <Compile Include="StandardChessBoardForm.cs">
       <SubType>Form</SubType>

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -17,12 +17,16 @@
  * 
  *********************************************************************************/
 using SysExtensions;
+using System;
+using System.IO;
 using System.Text;
 
 namespace Sandra.UI.WF
 {
     internal static class SettingKeys
     {
+        internal const string DefaultAppDataSubFolderName = "SandraChess";
+
         /// <summary>
         /// Converts a Pascal case identifier to snake case for use as a key in a settings file.
         /// </summary>
@@ -44,6 +48,21 @@ namespace Sandra.UI.WF
 
             return snakeCase.ToString();
         }
+
+        private static string localApplicationDataPath(bool isLocalSchema)
+            => !isLocalSchema ? string.Empty :
+            $" ({Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), DefaultAppDataSubFolderName)})";
+
+        internal static string DefaultSettingsSchemaDescription(bool isLocalSchema)
+            => "There are generally two copies of this file, one in the directory where "
+            + Path.GetFileName(typeof(Program).Assembly.Location)
+            + " is located ("
+            + Program.DefaultSettingsFileName
+            + "), and one that lives in the local application data folder"
+            + localApplicationDataPath(isLocalSchema)
+            + ". Preferences in the latter file override those that are specified in the default. "
+            + "In the majority of cases, only the latter file is changed, while the default "
+            + "settings serve as a template.";
 
         private const string AppDataSubFolderNameDescription
             = "Subfolder of %APPDATA%/Local which should be used to store persistent data. "
@@ -112,6 +131,7 @@ namespace Sandra.UI.WF
         private static SettingSchema CreateDefaultSettingsSchema()
         {
             return new SettingSchema(
+                SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false),
                 SettingKeys.AppDataSubFolderName,
                 SettingKeys.FastNavigationPlyCount);
         }
@@ -120,7 +140,7 @@ namespace Sandra.UI.WF
         {
             SettingCopy defaultSettings = new SettingCopy(DefaultSettingsSchema);
 
-            defaultSettings.AddOrReplace(SettingKeys.AppDataSubFolderName, "SandraChess");
+            defaultSettings.AddOrReplace(SettingKeys.AppDataSubFolderName, SettingKeys.DefaultAppDataSubFolderName);
 
             // 10 plies == 5 moves.
             defaultSettings.AddOrReplace(SettingKeys.FastNavigationPlyCount, 10);

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -53,16 +53,17 @@ namespace Sandra.UI.WF
             => !isLocalSchema ? string.Empty :
             $" ({Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), DefaultAppDataSubFolderName)})";
 
-        internal static string DefaultSettingsSchemaDescription(bool isLocalSchema)
-            => "There are generally two copies of this file, one in the directory where "
+        internal static SettingComment DefaultSettingsSchemaDescription(bool isLocalSchema) => new SettingComment(
+            "There are generally two copies of this file, one in the directory where "
             + Path.GetFileName(typeof(Program).Assembly.Location)
             + " is located ("
             + Program.DefaultSettingsFileName
             + "), and one that lives in the local application data folder"
             + localApplicationDataPath(isLocalSchema)
-            + ". Preferences in the latter file override those that are specified in the default. "
+            + ".",
+            "Preferences in the latter file override those that are specified in the default. "
             + "In the majority of cases, only the latter file is changed, while the default "
-            + "settings serve as a template.";
+            + "settings serve as a template.");
 
         private const string AppDataSubFolderNameDescription
             = "Subfolder of %APPDATA%/Local which should be used to store persistent data. "
@@ -131,7 +132,7 @@ namespace Sandra.UI.WF
         private static SettingSchema CreateDefaultSettingsSchema()
         {
             return new SettingSchema(
-                new SettingComment(SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false)),
+                SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false),
                 SettingKeys.AppDataSubFolderName,
                 SettingKeys.FastNavigationPlyCount);
         }

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -60,6 +60,28 @@ namespace Sandra.UI.WF
         internal static readonly SettingProperty<int> Zoom = new SettingProperty<int>(
             new SettingKey(nameof(Zoom).ToSnakeCase()),
             PType.RichTextZoomFactor.Instance);
+
+        internal static readonly SettingProperty<int> FastNavigationPlyCount = new SettingProperty<int>(
+            new SettingKey(nameof(FastNavigationPlyCount).ToSnakeCase()),
+            FastNavigationPlyCountRange.Instance);
+
+        private sealed class FastNavigationPlyCountRange : PType.Derived<PInteger, int>
+        {
+            public static readonly int MinPlyCount = 2;
+            public static readonly int MaxPlyCount = 40;
+
+            public static readonly FastNavigationPlyCountRange Instance = new FastNavigationPlyCountRange();
+
+            private FastNavigationPlyCountRange() : base(new PType.RangedInteger(MinPlyCount, MaxPlyCount)) { }
+
+            public override bool TryGetTargetValue(PInteger integer, out int targetValue)
+            {
+                targetValue = (int)integer.Value;
+                return true;
+            }
+
+            public override PInteger GetBaseValue(int value) => new PInteger(value);
+        }
     }
 
     internal static class Settings
@@ -79,7 +101,8 @@ namespace Sandra.UI.WF
         private static SettingSchema CreateDefaultSettingsSchema()
         {
             return new SettingSchema(
-                SettingKeys.AppDataSubFolderName);
+                SettingKeys.AppDataSubFolderName,
+                SettingKeys.FastNavigationPlyCount);
         }
 
         public static SettingCopy CreateBuiltIn()
@@ -87,6 +110,9 @@ namespace Sandra.UI.WF
             SettingCopy defaultSettings = new SettingCopy(DefaultSettingsSchema);
 
             defaultSettings.AddOrReplace(SettingKeys.AppDataSubFolderName, "SandraChess");
+
+            // 10 plies == 5 moves.
+            defaultSettings.AddOrReplace(SettingKeys.FastNavigationPlyCount, 10);
 
             return defaultSettings;
         }

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -27,6 +27,8 @@ namespace Sandra.UI.WF
     {
         internal const string DefaultAppDataSubFolderName = "SandraChess";
 
+        internal const string DefaultLocalPreferencesFileName = "Preferences.settings";
+
         /// <summary>
         /// Converts a Pascal case identifier to snake case for use as a key in a settings file.
         /// </summary>
@@ -75,6 +77,14 @@ namespace Sandra.UI.WF
             SubFolderNameType.Instance,
             new SettingComment(AppDataSubFolderNameDescription));
 
+        private const string LocalPreferencesFileNameDescription
+            = "File name in the %APPDATA%/Local subfolder which contains the user-specific preferences.";
+
+        internal static readonly SettingProperty<string> LocalPreferencesFileName = new SettingProperty<string>(
+            new SettingKey(nameof(LocalPreferencesFileName).ToSnakeCase()),
+            FileNameType.Instance,
+            new SettingComment(LocalPreferencesFileNameDescription));
+
         internal static readonly SettingProperty<PersistableFormState> Window = new SettingProperty<PersistableFormState>(
             new SettingKey(nameof(Window).ToSnakeCase()),
             PersistableFormState.Type);
@@ -121,6 +131,8 @@ namespace Sandra.UI.WF
 
         public static readonly SettingSchema DefaultSettingsSchema = CreateDefaultSettingsSchema();
 
+        public static readonly SettingSchema LocalSettingsSchema = CreateLocalSettingsSchema();
+
         private static SettingSchema CreateAutoSaveSchema()
         {
             return new SettingSchema(
@@ -134,6 +146,14 @@ namespace Sandra.UI.WF
             return new SettingSchema(
                 SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false),
                 SettingKeys.AppDataSubFolderName,
+                SettingKeys.LocalPreferencesFileName,
+                SettingKeys.FastNavigationPlyCount);
+        }
+
+        private static SettingSchema CreateLocalSettingsSchema()
+        {
+            return new SettingSchema(
+                SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: true),
                 SettingKeys.FastNavigationPlyCount);
         }
 
@@ -142,6 +162,7 @@ namespace Sandra.UI.WF
             SettingCopy defaultSettings = new SettingCopy(DefaultSettingsSchema);
 
             defaultSettings.AddOrReplace(SettingKeys.AppDataSubFolderName, SettingKeys.DefaultAppDataSubFolderName);
+            defaultSettings.AddOrReplace(SettingKeys.LocalPreferencesFileName, SettingKeys.DefaultLocalPreferencesFileName);
 
             // 10 plies == 5 moves.
             defaultSettings.AddOrReplace(SettingKeys.FastNavigationPlyCount, 10);

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -72,7 +72,7 @@ namespace Sandra.UI.WF
         internal static readonly SettingProperty<string> AppDataSubFolderName = new SettingProperty<string>(
             new SettingKey(nameof(AppDataSubFolderName).ToSnakeCase()),
             SubFolderNameType.Instance,
-            AppDataSubFolderNameDescription);
+            new SettingComment(AppDataSubFolderNameDescription));
 
         internal static readonly SettingProperty<PersistableFormState> Window = new SettingProperty<PersistableFormState>(
             new SettingKey(nameof(Window).ToSnakeCase()),
@@ -93,7 +93,7 @@ namespace Sandra.UI.WF
         internal static readonly SettingProperty<int> FastNavigationPlyCount = new SettingProperty<int>(
             new SettingKey(nameof(FastNavigationPlyCount).ToSnakeCase()),
             FastNavigationPlyCountRange.Instance,
-            FastNavigationPlyCountDescription);
+            new SettingComment(FastNavigationPlyCountDescription));
 
         private sealed class FastNavigationPlyCountRange : PType.Derived<PInteger, int>
         {
@@ -131,7 +131,7 @@ namespace Sandra.UI.WF
         private static SettingSchema CreateDefaultSettingsSchema()
         {
             return new SettingSchema(
-                SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false),
+                new SettingComment(SettingKeys.DefaultSettingsSchemaDescription(isLocalSchema: false)),
                 SettingKeys.AppDataSubFolderName,
                 SettingKeys.FastNavigationPlyCount);
         }

--- a/Sandra.UI.WF.Chess/Settings.cs
+++ b/Sandra.UI.WF.Chess/Settings.cs
@@ -45,9 +45,15 @@ namespace Sandra.UI.WF
             return snakeCase.ToString();
         }
 
+        private const string AppDataSubFolderNameDescription
+            = "Subfolder of %APPDATA%/Local which should be used to store persistent data. "
+            + "This includes the auto-save file, or e.g. a preferences file. "
+            + "Use forward slashes to separate directories, an unrecognized escape sequence such as in \"Test\\Test\" renders the whole file unusable.";
+
         internal static readonly SettingProperty<string> AppDataSubFolderName = new SettingProperty<string>(
             new SettingKey(nameof(AppDataSubFolderName).ToSnakeCase()),
-            SubFolderNameType.Instance);
+            SubFolderNameType.Instance,
+            AppDataSubFolderNameDescription);
 
         internal static readonly SettingProperty<PersistableFormState> Window = new SettingProperty<PersistableFormState>(
             new SettingKey(nameof(Window).ToSnakeCase()),
@@ -61,9 +67,14 @@ namespace Sandra.UI.WF
             new SettingKey(nameof(Zoom).ToSnakeCase()),
             PType.RichTextZoomFactor.Instance);
 
+        private const string FastNavigationPlyCountDescription
+            = "The number of plies (=half moves) to move forward of backward in a game for "
+            + "fast navigation. This value must be between 2 and 40.";
+
         internal static readonly SettingProperty<int> FastNavigationPlyCount = new SettingProperty<int>(
             new SettingKey(nameof(FastNavigationPlyCount).ToSnakeCase()),
-            FastNavigationPlyCountRange.Instance);
+            FastNavigationPlyCountRange.Instance,
+            FastNavigationPlyCountDescription);
 
         private sealed class FastNavigationPlyCountRange : PType.Derived<PInteger, int>
         {

--- a/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
@@ -1,5 +1,5 @@
 ﻿/*********************************************************************************
- * SettingsTextBox.cs
+ * SettingsTextBox.UIActions.cs
  * 
  * Copyright (c) 2004-2018 Henk Nicolai
  * 
@@ -16,12 +16,28 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
+using System;
+
 namespace Sandra.UI.WF
 {
-    /// <summary>
-    /// Represents a read-only Windows rich text box which displays a json settings file.
-    /// </summary>
-    public partial class SettingsTextBox : RichTextBoxBase
+    public partial class SettingsTextBox
     {
+        public const string SettingsTextBoxUIActionPrefix = nameof(RichTextBoxBase) + ".";
+
+        public static readonly DefaultUIActionBinding SaveToFile = new DefaultUIActionBinding(
+            new UIAction(SettingsTextBoxUIActionPrefix + nameof(SaveToFile)),
+            new UIActionBinding()
+            {
+                ShowInMenu = true,
+                IsFirstInGroup = true,
+                MenuCaptionKey = LocalizedStringKeys.Save,
+                Shortcuts = new ShortcutKeys[] { new ShortcutKeys(KeyModifiers.Control, ConsoleKey.S), },
+            });
+
+        public UIActionState TrySaveToFile(bool perform)
+        {
+            if (ReadOnly) return UIActionVisibility.Hidden;
+            return UIActionVisibility.Enabled;
+        }
     }
 }

--- a/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
@@ -17,6 +17,7 @@
  * 
  *********************************************************************************/
 using System;
+using System.IO;
 
 namespace Sandra.UI.WF
 {
@@ -37,6 +38,7 @@ namespace Sandra.UI.WF
         public UIActionState TrySaveToFile(bool perform)
         {
             if (ReadOnly) return UIActionVisibility.Hidden;
+            if (perform) File.WriteAllText(settingsFile.AbsoluteFilePath, Text);
             return UIActionVisibility.Enabled;
         }
     }

--- a/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.UIActions.cs
@@ -23,7 +23,7 @@ namespace Sandra.UI.WF
 {
     public partial class SettingsTextBox
     {
-        public const string SettingsTextBoxUIActionPrefix = nameof(RichTextBoxBase) + ".";
+        public const string SettingsTextBoxUIActionPrefix = nameof(SettingsTextBox) + ".";
 
         public static readonly DefaultUIActionBinding SaveToFile = new DefaultUIActionBinding(
             new UIAction(SettingsTextBoxUIActionPrefix + nameof(SaveToFile)),

--- a/Sandra.UI.WF.Chess/SettingsTextBox.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.cs
@@ -22,7 +22,7 @@ using System.IO;
 namespace Sandra.UI.WF
 {
     /// <summary>
-    /// Represents a read-only Windows rich text box which displays a json settings file.
+    /// Represents a Windows rich text box which displays a json settings file.
     /// </summary>
     public partial class SettingsTextBox : RichTextBoxBase
     {

--- a/Sandra.UI.WF.Chess/SettingsTextBox.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.cs
@@ -1,0 +1,37 @@
+﻿/*********************************************************************************
+ * SettingsTextBox.cs
+ * 
+ * Copyright (c) 2004-2018 Henk Nicolai
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * 
+ *********************************************************************************/
+using System.Drawing;
+
+namespace Sandra.UI.WF
+{
+    /// <summary>
+    /// Represents a read-only Windows rich text box which displays a json settings file.
+    /// </summary>
+    public class SettingsTextBox : UpdatableRichTextBox, IUIActionHandlerProvider
+    {
+        public SettingsTextBox()
+        {
+        }
+
+        /// <summary>
+        /// Gets the action handler for this control.
+        /// </summary>
+        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
+    }
+}

--- a/Sandra.UI.WF.Chess/SettingsTextBox.cs
+++ b/Sandra.UI.WF.Chess/SettingsTextBox.cs
@@ -16,6 +16,9 @@
  *    limitations under the License.
  * 
  *********************************************************************************/
+using System;
+using System.IO;
+
 namespace Sandra.UI.WF
 {
     /// <summary>
@@ -23,5 +26,22 @@ namespace Sandra.UI.WF
     /// </summary>
     public partial class SettingsTextBox : RichTextBoxBase
     {
+        private readonly SettingsFile settingsFile;
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="SettingsTextBox"/>.
+        /// </summary>
+        /// <param name="settingsFile">
+        /// The settings file to show and/or edit.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="settingsFile"/> is null.
+        /// </exception>
+        public SettingsTextBox(SettingsFile settingsFile)
+        {
+            if (settingsFile == null) throw new ArgumentNullException(nameof(settingsFile));
+            this.settingsFile = settingsFile;
+            Text = File.ReadAllText(settingsFile.AbsoluteFilePath);
+        }
     }
 }

--- a/Sandra.UI.WF.Chess/UIActionForm.cs
+++ b/Sandra.UI.WF.Chess/UIActionForm.cs
@@ -1,0 +1,48 @@
+﻿/*********************************************************************************
+ * UIActionForm.cs
+ * 
+ * Copyright (c) 2004-2018 Henk Nicolai
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * 
+ *********************************************************************************/
+using System;
+using System.Windows.Forms;
+
+namespace Sandra.UI.WF
+{
+    /// <summary>
+    /// Top level Form which ties in with the UIAction framework.
+    /// </summary>
+    public class UIActionForm : Form, IUIActionHandlerProvider
+    {
+        /// <summary>
+        /// Gets the action handler for this control.
+        /// </summary>
+        public UIActionHandler ActionHandler { get; } = new UIActionHandler();
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            try
+            {
+                // This code makes shortcuts work for all UIActionHandlers.
+                return KeyUtils.TryExecute(keyData) || base.ProcessCmdKey(ref msg, keyData);
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show(e.Message);
+                return true;
+            }
+        }
+    }
+}

--- a/Sandra.UI.WF/Sandra.UI.WF.csproj
+++ b/Sandra.UI.WF/Sandra.UI.WF.csproj
@@ -65,6 +65,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Settings\AutoSave.cs" />
+    <Compile Include="Settings\FileNameType.cs" />
     <Compile Include="Settings\PersistableFormState.cs" />
     <Compile Include="Settings\PList.cs" />
     <Compile Include="Settings\PMap.cs" />

--- a/Sandra.UI.WF/Sandra.UI.WF.csproj
+++ b/Sandra.UI.WF/Sandra.UI.WF.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Settings\PType.Common.cs" />
     <Compile Include="Settings\PType.cs" />
     <Compile Include="Settings\PValue.cs" />
+    <Compile Include="Settings\SettingComment.cs" />
     <Compile Include="Settings\SettingCopy.cs" />
     <Compile Include="Settings\SettingKey.cs" />
     <Compile Include="Settings\SettingObject.cs" />

--- a/Sandra.UI.WF/Settings/AutoSave.cs
+++ b/Sandra.UI.WF/Settings/AutoSave.cs
@@ -338,7 +338,7 @@ namespace Sandra.UI.WF
 
                     try
                     {
-                        var writer = new SettingWriter(compact: true);
+                        var writer = new SettingWriter(compact: true, schema: remoteSettings.Schema);
                         writer.Visit(remoteSettings.Map);
 
                         // Alterate between both auto-save files.

--- a/Sandra.UI.WF/Settings/AutoSave.cs
+++ b/Sandra.UI.WF/Settings/AutoSave.cs
@@ -338,7 +338,7 @@ namespace Sandra.UI.WF
 
                     try
                     {
-                        var writer = new SettingWriter(indented: false);
+                        var writer = new SettingWriter(compact: true);
                         writer.Visit(remoteSettings.Map);
 
                         // Alterate between both auto-save files.

--- a/Sandra.UI.WF/Settings/FileNameType.cs
+++ b/Sandra.UI.WF/Settings/FileNameType.cs
@@ -1,0 +1,37 @@
+﻿/*********************************************************************************
+ * FileNameType.cs
+ * 
+ * Copyright (c) 2004-2018 Henk Nicolai
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * 
+ *********************************************************************************/
+using System.IO;
+
+namespace Sandra.UI.WF
+{
+    /// <summary>
+    /// Specialized PType that only accepts a strings that are legal file names.
+    /// </summary>
+    public sealed class FileNameType : PType.Filter<string>
+    {
+        public static FileNameType Instance = new FileNameType();
+
+        private FileNameType() : base(PType.CLR.String) { }
+
+        public override bool IsValid(string fileName)
+            => !string.IsNullOrEmpty(fileName)
+            && !fileName.StartsWith(".")
+            && fileName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
+    }
+}

--- a/Sandra.UI.WF/Settings/SettingComment.cs
+++ b/Sandra.UI.WF/Settings/SettingComment.cs
@@ -1,0 +1,42 @@
+﻿/*********************************************************************************
+ * SettingComment.cs
+ * 
+ * Copyright (c) 2004-2018 Henk Nicolai
+ * 
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * 
+ *********************************************************************************/
+using System;
+
+namespace Sandra.UI.WF
+{
+    /// <summary>
+    /// Represents a comment in a setting file.
+    /// </summary>
+    public class SettingComment
+    {
+        public string Text { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SettingComment"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="text"/> is null.
+        /// </exception>
+        public SettingComment(string text)
+        {
+            if (text == null) throw new ArgumentNullException(nameof(text));
+            Text = text;
+        }
+    }
+}

--- a/Sandra.UI.WF/Settings/SettingComment.cs
+++ b/Sandra.UI.WF/Settings/SettingComment.cs
@@ -17,6 +17,7 @@
  * 
  *********************************************************************************/
 using System;
+using System.Collections.Generic;
 
 namespace Sandra.UI.WF
 {
@@ -25,7 +26,7 @@ namespace Sandra.UI.WF
     /// </summary>
     public class SettingComment
     {
-        public string Text { get; }
+        public IEnumerable<string> Paragraphs { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="SettingComment"/>.
@@ -36,7 +37,31 @@ namespace Sandra.UI.WF
         public SettingComment(string text)
         {
             if (text == null) throw new ArgumentNullException(nameof(text));
-            Text = text;
+            Paragraphs = new string[] { text };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SettingComment"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="paragraphs"/> is null.
+        /// </exception>
+        public SettingComment(params string[] paragraphs)
+        {
+            if (paragraphs == null) throw new ArgumentNullException(nameof(paragraphs));
+            Paragraphs = paragraphs;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SettingComment"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="paragraphs"/> is null.
+        /// </exception>
+        public SettingComment(IEnumerable<string> paragraphs)
+        {
+            if (paragraphs == null) throw new ArgumentNullException(nameof(paragraphs));
+            Paragraphs = paragraphs;
         }
     }
 }

--- a/Sandra.UI.WF/Settings/SettingCopy.cs
+++ b/Sandra.UI.WF/Settings/SettingCopy.cs
@@ -64,7 +64,7 @@ namespace Sandra.UI.WF
         /// The new value to associate with the property.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="value"/> is null.
+        /// <paramref name="property"/> and/or <paramref name="value"/> are null.
         /// </exception>
         public void AddOrReplace<TValue>(SettingProperty<TValue> property, TValue value)
         {
@@ -73,6 +73,36 @@ namespace Sandra.UI.WF
             if (Schema.ContainsProperty(property))
             {
                 KeyValueMapping[property.Name] = property.PType.GetPValue(value);
+            }
+        }
+
+        /// <summary>
+        /// Adds or replaces a value from a source <see cref="SettingObject"/> with a different schema.
+        /// </summary>
+        /// <param name="property">
+        /// The property for which to add or replace the value.
+        /// </param>
+        /// <param name="source">
+        /// The source <see cref="SettingObject"/> to take the value from.
+        /// </param>
+        /// <param name="sourceProperty">
+        /// The source <see cref="SettingProperty"/> to take the value from.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> and/or <paramref name="source"/> and/or <paramref name="sourceProperty"/> are null.
+        /// </exception>
+        public void AddOrReplace(SettingProperty property, SettingObject source, SettingProperty sourceProperty)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (sourceProperty == null) throw new ArgumentNullException(nameof(sourceProperty));
+
+            PValue sourceValue;
+            if (Schema.ContainsProperty(property)
+                && source.TryGetPValue(sourceProperty, out sourceValue)
+                && property.IsValidValue(sourceValue))
+            {
+                KeyValueMapping[property.Name] = sourceValue;
             }
         }
 

--- a/Sandra.UI.WF/Settings/SettingObject.cs
+++ b/Sandra.UI.WF/Settings/SettingObject.cs
@@ -40,6 +40,37 @@ namespace Sandra.UI.WF
         }
 
         /// <summary>
+        /// Gets the <see cref="PValue"/> that is associated with the specified property.
+        /// </summary>
+        /// <param name="property">
+        /// The property to locate.
+        /// </param>
+        /// <param name="value">
+        /// When this method returns, contains the value associated with the specified property,
+        /// if the property is found; otherwise, the default <see cref="PValue"/> value.
+        /// This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>
+        /// true if this <see cref="SettingObject"/> contains a value for the specified property;
+        /// otherwise, false.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="property"/> is null.
+        /// </exception>
+        public bool TryGetPValue(SettingProperty property, out PValue value)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+
+            if (Schema.ContainsProperty(property)
+                && Map.TryGetValue(property.Name.Key, out value))
+            {
+                return true;
+            }
+            value = default(PValue);
+            return false;
+        }
+
+        /// <summary>
         /// Gets the value that is associated with the specified property.
         /// </summary>
         /// <param name="property">
@@ -60,11 +91,8 @@ namespace Sandra.UI.WF
         /// </exception>
         public bool TryGetValue<TValue>(SettingProperty<TValue> property, out TValue value)
         {
-            if (property == null) throw new ArgumentNullException(nameof(property));
-
             PValue pValue;
-            if (Schema.ContainsProperty(property)
-                && Map.TryGetValue(property.Name.Key, out pValue)
+            if (TryGetPValue(property, out pValue)
                 && property.TryGetValidValue(pValue, out value))
             {
                 return true;

--- a/Sandra.UI.WF/Settings/SettingProperty.cs
+++ b/Sandra.UI.WF/Settings/SettingProperty.cs
@@ -41,6 +41,9 @@ namespace Sandra.UI.WF
         /// <param name="name">
         /// The name of the property.
         /// </param>
+        /// <param name="description">
+        /// The built-in description of the property in a settings file.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> is null.
         /// </exception>

--- a/Sandra.UI.WF/Settings/SettingProperty.cs
+++ b/Sandra.UI.WF/Settings/SettingProperty.cs
@@ -66,6 +66,11 @@ namespace Sandra.UI.WF
     public class SettingProperty<T> : SettingProperty
     {
         /// <summary>
+        /// Gets the built-in description of the property in a settings file.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
         /// Gets the type of value that it contains.
         /// </summary>
         public PType<T> PType { get; }
@@ -82,10 +87,31 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> and/or <paramref name="pType"/> are null.
         /// </exception>
-        public SettingProperty(SettingKey name, PType<T> pType) : base(name)
+        public SettingProperty(SettingKey name, PType<T> pType) : this(name, pType, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SettingProperty"/>.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the property.
+        /// </param>
+        /// <param name="pType">
+        /// The type of value that it contains.
+        /// </param>
+        /// <param name="description">
+        /// The built-in description of the property in a settings file.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="name"/> and/or <paramref name="pType"/> are null.
+        /// </exception>
+        public SettingProperty(SettingKey name, PType<T> pType, string description) : base(name)
         {
             if (pType == null) throw new ArgumentNullException(nameof(pType));
+
             PType = pType;
+            Description = description;
         }
 
         /// <summary>

--- a/Sandra.UI.WF/Settings/SettingProperty.cs
+++ b/Sandra.UI.WF/Settings/SettingProperty.cs
@@ -31,6 +31,11 @@ namespace Sandra.UI.WF
         public SettingKey Name { get; }
 
         /// <summary>
+        /// Gets the built-in description of the property in a settings file.
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="SettingProperty"/>.
         /// </summary>
         /// <param name="name">
@@ -39,10 +44,12 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> is null.
         /// </exception>
-        public SettingProperty(SettingKey name)
+        public SettingProperty(SettingKey name, string description)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
+
             Name = name;
+            Description = description;
         }
 
         /// <summary>
@@ -65,11 +72,6 @@ namespace Sandra.UI.WF
     /// </typeparam>
     public class SettingProperty<T> : SettingProperty
     {
-        /// <summary>
-        /// Gets the built-in description of the property in a settings file.
-        /// </summary>
-        public string Description { get; }
-
         /// <summary>
         /// Gets the type of value that it contains.
         /// </summary>
@@ -106,12 +108,10 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> and/or <paramref name="pType"/> are null.
         /// </exception>
-        public SettingProperty(SettingKey name, PType<T> pType, string description) : base(name)
+        public SettingProperty(SettingKey name, PType<T> pType, string description) : base(name, description)
         {
             if (pType == null) throw new ArgumentNullException(nameof(pType));
-
             PType = pType;
-            Description = description;
         }
 
         /// <summary>

--- a/Sandra.UI.WF/Settings/SettingProperty.cs
+++ b/Sandra.UI.WF/Settings/SettingProperty.cs
@@ -33,7 +33,7 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Gets the built-in description of the property in a settings file.
         /// </summary>
-        public string Description { get; }
+        public SettingComment Description { get; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="SettingProperty"/>.
@@ -47,7 +47,7 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> is null.
         /// </exception>
-        public SettingProperty(SettingKey name, string description)
+        public SettingProperty(SettingKey name, SettingComment description)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
@@ -111,7 +111,7 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentNullException">
         /// <paramref name="name"/> and/or <paramref name="pType"/> are null.
         /// </exception>
-        public SettingProperty(SettingKey name, PType<T> pType, string description) : base(name, description)
+        public SettingProperty(SettingKey name, PType<T> pType, SettingComment description) : base(name, description)
         {
             if (pType == null) throw new ArgumentNullException(nameof(pType));
             PType = pType;

--- a/Sandra.UI.WF/Settings/SettingSchema.cs
+++ b/Sandra.UI.WF/Settings/SettingSchema.cs
@@ -146,5 +146,10 @@ namespace Sandra.UI.WF
             return properties.TryGetValue(property.Name.Key, out propertyInDictionary)
                 && property == propertyInDictionary;
         }
+
+        /// <summary>
+        /// Enumerates all properties in this schema.
+        /// </summary>
+        public IEnumerable<SettingProperty> AllProperties => properties.Values;
     }
 }

--- a/Sandra.UI.WF/Settings/SettingSchema.cs
+++ b/Sandra.UI.WF/Settings/SettingSchema.cs
@@ -30,9 +30,14 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Represents the empty <see cref="SettingSchema"/>, which contains no properties.
         /// </summary>
-        public static readonly SettingSchema Empty = new SettingSchema(null);
+        public static readonly SettingSchema Empty = new SettingSchema((string)null);
 
         private readonly Dictionary<string, SettingProperty> properties;
+
+        /// <summary>
+        /// Gets the built-in description of the schema in a settings file.
+        /// </summary>
+        public string Description { get; }
 
         /// <summary>
         /// Initializes a new instance of a <see cref="SettingSchema"/>.
@@ -43,7 +48,25 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentException">
         /// Two or more properties have the same key.
         /// </exception>
-        public SettingSchema(params SettingProperty[] properties) : this((IEnumerable<SettingProperty>)properties)
+        public SettingSchema(params SettingProperty[] properties)
+            : this((IEnumerable<SettingProperty>)properties)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of a <see cref="SettingSchema"/>.
+        /// </summary>
+        /// <param name="description">
+        /// The built-in description of the schema in a settings file.
+        /// </param>
+        /// <param name="properties">
+        /// The set of properties with unique keys to support.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Two or more properties have the same key.
+        /// </exception>
+        public SettingSchema(string description, params SettingProperty[] properties)
+            : this(properties, description)
         {
         }
 
@@ -53,10 +76,13 @@ namespace Sandra.UI.WF
         /// <param name="properties">
         /// The set of properties with unique keys to support.
         /// </param>
+        /// <param name="description">
+        /// The built-in description of the schema in a settings file.
+        /// </param>
         /// <exception cref="ArgumentException">
         /// Two or more properties have the same key; or one of the properties is null.
         /// </exception>
-        public SettingSchema(IEnumerable<SettingProperty> properties)
+        public SettingSchema(IEnumerable<SettingProperty> properties, string description = null)
         {
             this.properties = properties != null && properties.Any()
                 ? new Dictionary<string, SettingProperty>()
@@ -70,6 +96,8 @@ namespace Sandra.UI.WF
                     this.properties.Add(property.Name.Key, property);
                 }
             }
+
+            Description = description;
         }
 
         /// <summary>

--- a/Sandra.UI.WF/Settings/SettingSchema.cs
+++ b/Sandra.UI.WF/Settings/SettingSchema.cs
@@ -30,14 +30,14 @@ namespace Sandra.UI.WF
         /// <summary>
         /// Represents the empty <see cref="SettingSchema"/>, which contains no properties.
         /// </summary>
-        public static readonly SettingSchema Empty = new SettingSchema((string)null);
+        public static readonly SettingSchema Empty = new SettingSchema((SettingComment)null);
 
         private readonly Dictionary<string, SettingProperty> properties;
 
         /// <summary>
         /// Gets the built-in description of the schema in a settings file.
         /// </summary>
-        public string Description { get; }
+        public SettingComment Description { get; }
 
         /// <summary>
         /// Initializes a new instance of a <see cref="SettingSchema"/>.
@@ -65,7 +65,7 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentException">
         /// Two or more properties have the same key.
         /// </exception>
-        public SettingSchema(string description, params SettingProperty[] properties)
+        public SettingSchema(SettingComment description, params SettingProperty[] properties)
             : this(properties, description)
         {
         }
@@ -82,7 +82,7 @@ namespace Sandra.UI.WF
         /// <exception cref="ArgumentException">
         /// Two or more properties have the same key; or one of the properties is null.
         /// </exception>
-        public SettingSchema(IEnumerable<SettingProperty> properties, string description = null)
+        public SettingSchema(IEnumerable<SettingProperty> properties, SettingComment description = null)
         {
             this.properties = properties != null && properties.Any()
                 ? new Dictionary<string, SettingProperty>()

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -54,10 +54,11 @@ namespace Sandra.UI.WF
             private const int maxLineLength = 80;
             private const string startComment = "// ";
 
-            private static List<string> GetCommentLines(string commentText, int indent)
+            private static List<string> GetCommentLines(SettingComment comment, int indent)
             {
                 List<string> lines = new List<string>();
-                if (commentText == null) return lines;
+                if (comment == null) return lines;
+                string commentText = comment.Text;
 
                 // Cut up the description in pieces.
                 // Available length depends on the current indent level.

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -42,7 +42,7 @@ namespace Sandra.UI.WF
             if (indented)
             {
                 jsonTextWriter.Formatting = Formatting.Indented;
-                jsonTextWriter.Indentation = 4;
+                jsonTextWriter.Indentation = 2;
                 jsonTextWriter.IndentChar = ' ';
             }
         }

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -31,8 +31,11 @@ namespace Sandra.UI.WF
     {
         private class JsonPrettyPrinter : JsonTextWriter
         {
-            public JsonPrettyPrinter(TextWriter writer) : base(writer)
+            private readonly SettingSchema schema;
+
+            public JsonPrettyPrinter(TextWriter writer, SettingSchema schema) : base(writer)
             {
+                this.schema = schema;
                 Formatting = Formatting.Indented;
                 Indentation = 2;
                 IndentChar = ' ';
@@ -49,12 +52,13 @@ namespace Sandra.UI.WF
         private readonly StringBuilder outputBuilder;
         private readonly JsonTextWriter jsonTextWriter;
 
-        public SettingWriter(bool compact)
+        public SettingWriter(bool compact, SettingSchema schema)
         {
             outputBuilder = new StringBuilder();
             var stringWriter = new StringWriter(outputBuilder);
             stringWriter.NewLine = Environment.NewLine;
-            jsonTextWriter = compact ? new JsonTextWriter(stringWriter) : new JsonPrettyPrinter(stringWriter);
+            jsonTextWriter = compact ? new JsonTextWriter(stringWriter)
+                                     : new JsonPrettyPrinter(stringWriter, schema);
         }
 
         public override void VisitBoolean(PBoolean value)

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -132,6 +132,19 @@ namespace Sandra.UI.WF
                 Formatting = Formatting.Indented;
                 Indentation = 2;
                 IndentChar = ' ';
+
+                // Write schema description, if any.
+                var commentLines = GetCommentLines(schema.Description, 0);
+                foreach (string commentLine in commentLines)
+                {
+                    // The base WriteComment wraps comments in /*-*/ delimiters,
+                    // so generate raw comments starting with // instead.
+                    WriteRaw(startComment);
+                    WriteRaw(commentLine);
+
+                    // Do this at the end to generate a line-break.
+                    WriteIndent();
+                }
             }
 
             protected override void WriteValueDelimiter()

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -185,7 +185,7 @@ namespace Sandra.UI.WF
                             // This happens in WritePropertyName().
                             WriteValueDelimiter();
                             suppressNextValueDelimiter = true;
-                            WriteIndent();
+                            WriteWhitespace(newLine);
                         }
 
                         foreach (string commentLine in commentLines)

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -29,15 +29,22 @@ namespace Sandra.UI.WF
     /// </summary>
     internal class SettingWriter : PValueVisitor
     {
+        private class CustomJsonTextWriter : JsonTextWriter
+        {
+            public CustomJsonTextWriter(TextWriter writer) : base(writer)
+            {
+            }
+        }
+
         private readonly StringBuilder outputBuilder;
-        private readonly JsonTextWriter jsonTextWriter;
+        private readonly CustomJsonTextWriter jsonTextWriter;
 
         public SettingWriter(bool indented)
         {
             outputBuilder = new StringBuilder();
             var stringWriter = new StringWriter(outputBuilder);
             stringWriter.NewLine = Environment.NewLine;
-            jsonTextWriter = new JsonTextWriter(stringWriter);
+            jsonTextWriter = new CustomJsonTextWriter(stringWriter);
 
             if (indented)
             {

--- a/Sandra.UI.WF/Settings/SettingWriter.cs
+++ b/Sandra.UI.WF/Settings/SettingWriter.cs
@@ -54,11 +54,10 @@ namespace Sandra.UI.WF
             private const int maxLineLength = 80;
             private const string startComment = "// ";
 
-            private static List<string> GetCommentLines(SettingComment comment, int indent)
+            private static IEnumerable<string> GetCommentLines(string commentText, int indent)
             {
                 List<string> lines = new List<string>();
-                if (comment == null) return lines;
-                string commentText = comment.Text;
+                if (commentText == null) return lines;
 
                 // Cut up the description in pieces.
                 // Available length depends on the current indent level.
@@ -121,6 +120,22 @@ namespace Sandra.UI.WF
                 return lines;
             }
 
+            private static List<string> GetCommentLines(SettingComment comment, int indent)
+            {
+                List<string> lines = new List<string>();
+                if (comment != null)
+                {
+                    bool first = true;
+                    foreach (var paragraph in comment.Paragraphs)
+                    {
+                        if (!first) lines.Add(string.Empty);
+                        first = false;
+                        lines.AddRange(GetCommentLines(paragraph, indent));
+                    }
+                }
+                return lines;
+            }
+
             private readonly SettingSchema schema;
             private readonly string newLine;
 
@@ -135,8 +150,7 @@ namespace Sandra.UI.WF
                 IndentChar = ' ';
 
                 // Write schema description, if any.
-                var commentLines = GetCommentLines(schema.Description, 0);
-                foreach (string commentLine in commentLines)
+                foreach (string commentLine in GetCommentLines(schema.Description, 0))
                 {
                     // The base WriteComment wraps comments in /*-*/ delimiters,
                     // so generate raw comments starting with // instead.

--- a/Sandra.UI.WF/Settings/SettingsFile.cs
+++ b/Sandra.UI.WF/Settings/SettingsFile.cs
@@ -103,8 +103,14 @@ namespace Sandra.UI.WF
         /// Null if the operation was successful;
         /// otherwise the <see cref="Exception"/> which caused the operation to fail.
         /// </returns>
+#if DEBUG
+        public Exception WriteToFile(string absoluteFilePath = null)
+        {
+            absoluteFilePath = absoluteFilePath ?? this.absoluteFilePath;
+#else
         public Exception WriteToFile()
         {
+#endif
             SettingWriter writer = new SettingWriter(compact: false, schema: Settings.Schema);
             writer.Visit(Settings.Map);
             try

--- a/Sandra.UI.WF/Settings/SettingsFile.cs
+++ b/Sandra.UI.WF/Settings/SettingsFile.cs
@@ -105,7 +105,7 @@ namespace Sandra.UI.WF
         /// </returns>
         public Exception WriteToFile()
         {
-            SettingWriter writer = new SettingWriter(compact: false);
+            SettingWriter writer = new SettingWriter(compact: false, schema: Settings.Schema);
             writer.Visit(Settings.Map);
             try
             {

--- a/Sandra.UI.WF/Settings/SettingsFile.cs
+++ b/Sandra.UI.WF/Settings/SettingsFile.cs
@@ -109,7 +109,7 @@ namespace Sandra.UI.WF
 #if DEBUG
         public Exception WriteToFile(string absoluteFilePath = null)
         {
-            absoluteFilePath = absoluteFilePath ?? this.AbsoluteFilePath;
+            absoluteFilePath = absoluteFilePath ?? AbsoluteFilePath;
 #else
         public Exception WriteToFile()
         {

--- a/Sandra.UI.WF/Settings/SettingsFile.cs
+++ b/Sandra.UI.WF/Settings/SettingsFile.cs
@@ -105,7 +105,7 @@ namespace Sandra.UI.WF
         /// </returns>
         public Exception WriteToFile()
         {
-            SettingWriter writer = new SettingWriter(indented: true);
+            SettingWriter writer = new SettingWriter(compact: false);
             writer.Visit(Settings.Map);
             try
             {

--- a/Sandra.UI.WF/Settings/SettingsFile.cs
+++ b/Sandra.UI.WF/Settings/SettingsFile.cs
@@ -86,13 +86,16 @@ namespace Sandra.UI.WF
             return new SettingsFile(absoluteFilePath, workingCopy.Commit());
         }
 
-        private readonly string absoluteFilePath;
+        /// <summary>
+        /// Returns the full path to the settings file.
+        /// </summary>
+        public string AbsoluteFilePath { get; }
 
         public SettingObject Settings { get; }
 
         private SettingsFile(string absoluteFilePath, SettingObject settings)
         {
-            this.absoluteFilePath = absoluteFilePath;
+            AbsoluteFilePath = absoluteFilePath;
             Settings = settings;
         }
 
@@ -106,7 +109,7 @@ namespace Sandra.UI.WF
 #if DEBUG
         public Exception WriteToFile(string absoluteFilePath = null)
         {
-            absoluteFilePath = absoluteFilePath ?? this.absoluteFilePath;
+            absoluteFilePath = absoluteFilePath ?? this.AbsoluteFilePath;
 #else
         public Exception WriteToFile()
         {


### PR DESCRIPTION
First setting to go into local preferences is FastNavigationPlyCount.
Also adds cut/paste actions to richtext boxes.
LocalSettings is copied from DefaultSettings, then overwritten from Preferences.settings file.
Both settings files can be viewed, the latter can also be edited and saved.
Also works if no Default.settings file is present, the built-in copy is used instead.