### PR TITLE
Parser improvements

### DIFF
--- a/Eutherion/Shared/Eutherion.Shared.csproj
+++ b/Eutherion/Shared/Eutherion.Shared.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Localization\LocalizedStringKey.cs" />
     <Compile Include="Localization\Localizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Text\ISpan.cs" />
     <Compile Include="Text\Json\JsonBackgroundSyntax.cs" />
     <Compile Include="Text\Json\JsonBooleanLiteralSyntax.cs" />
     <Compile Include="Text\Json\JsonColon.cs" />

--- a/Eutherion/Shared/Eutherion.Shared.csproj
+++ b/Eutherion/Shared/Eutherion.Shared.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Text\Json\JsonValueSyntaxVisitor.cs" />
     <Compile Include="Text\Json\JsonValueWithBackgroundSyntax.cs" />
     <Compile Include="Text\Json\JsonWhitespace.cs" />
+    <Compile Include="Text\ReadOnlySeparatedSpanList.cs" />
     <Compile Include="Text\ReadOnlySpanList.cs" />
     <Compile Include="Text\TextElement.cs" />
     <Compile Include="Text\TextIndex.cs" />

--- a/Eutherion/Shared/Eutherion.Shared.csproj
+++ b/Eutherion/Shared/Eutherion.Shared.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Utils\ObservableValue.cs" />
     <Compile Include="Utils\ReadOnlyList.cs" />
     <Compile Include="Utils\SafeLazy.cs" />
+    <Compile Include="Utils\SpecializedEnumerable.cs" />
     <Compile Include="Utils\StringUtilities.cs" />
     <Compile Include="Utils\Union.cs" />
     <Compile Include="Utils\WeakEvent.cs" />

--- a/Eutherion/Shared/Eutherion.Shared.csproj
+++ b/Eutherion/Shared/Eutherion.Shared.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Text\Json\JsonValueSyntaxVisitor.cs" />
     <Compile Include="Text\Json\JsonValueWithBackgroundSyntax.cs" />
     <Compile Include="Text\Json\JsonWhitespace.cs" />
+    <Compile Include="Text\ReadOnlySpanList.cs" />
     <Compile Include="Text\TextElement.cs" />
     <Compile Include="Text\TextIndex.cs" />
     <Compile Include="UIActions\DefaultUIActionBinding.cs" />

--- a/Eutherion/Shared/Text/ISpan.cs
+++ b/Eutherion/Shared/Text/ISpan.cs
@@ -1,0 +1,34 @@
+﻿#region License
+/*********************************************************************************
+ * ISpan.cs
+ *
+ * Copyright (c) 2004-2019 Henk Nicolai
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+**********************************************************************************/
+#endregion
+
+namespace Eutherion.Text
+{
+    /// <summary>
+    /// Represents something with a measure of length between a begin and an end point.
+    /// </summary>
+    public interface ISpan
+    {
+        /// <summary>
+        /// Gets the length.
+        /// </summary>
+        int Length { get; }
+    }
+}

--- a/Eutherion/Shared/Text/Json/JsonBackgroundSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonBackgroundSyntax.cs
@@ -29,7 +29,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Represents a node with background symbols in an abstract json syntax tree.
     /// </summary>
-    public class JsonBackgroundSyntax
+    public sealed class JsonBackgroundSyntax
     {
         /// <summary>
         /// Gets the empty <see cref="JsonBackgroundSyntax"/>.

--- a/Eutherion/Shared/Text/Json/JsonBackgroundSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonBackgroundSyntax.cs
@@ -29,7 +29,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Represents a node with background symbols in an abstract json syntax tree.
     /// </summary>
-    public sealed class JsonBackgroundSyntax
+    public sealed class JsonBackgroundSyntax : ISpan
     {
         /// <summary>
         /// Gets the empty <see cref="JsonBackgroundSyntax"/>.

--- a/Eutherion/Shared/Text/Json/JsonColon.cs
+++ b/Eutherion/Shared/Text/Json/JsonColon.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonColon : JsonSymbol
+    public sealed class JsonColon : JsonSymbol
     {
         public const char ColonCharacter = ':';
         public const int ColonLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonComma.cs
+++ b/Eutherion/Shared/Text/Json/JsonComma.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonComma : JsonSymbol
+    public sealed class JsonComma : JsonSymbol
     {
         public const char CommaCharacter = ',';
         public const int CommaLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonComment.cs
+++ b/Eutherion/Shared/Text/Json/JsonComment.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonComment : JsonSymbol
+    public sealed class JsonComment : JsonSymbol
     {
         public const char CommentStartFirstCharacter = '/';
         public const char SingleLineCommentStartSecondCharacter = '/';

--- a/Eutherion/Shared/Text/Json/JsonCurlyClose.cs
+++ b/Eutherion/Shared/Text/Json/JsonCurlyClose.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonCurlyClose : JsonSymbol
+    public sealed class JsonCurlyClose : JsonSymbol
     {
         public const char CurlyCloseCharacter = '}';
         public const int CurlyCloseLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonCurlyOpen.cs
+++ b/Eutherion/Shared/Text/Json/JsonCurlyOpen.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonCurlyOpen : JsonSymbol
+    public sealed class JsonCurlyOpen : JsonSymbol
     {
         public const char CurlyOpenCharacter = '{';
         public const int CurlyOpenLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonErrorInfo.cs
+++ b/Eutherion/Shared/Text/Json/JsonErrorInfo.cs
@@ -26,7 +26,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Reports an error at a certain location in a source text.
     /// </summary>
-    public class JsonErrorInfo
+    public class JsonErrorInfo : ISpan
     {
         /// <summary>
         /// Gets the error code.

--- a/Eutherion/Shared/Text/Json/JsonErrorString.cs
+++ b/Eutherion/Shared/Text/Json/JsonErrorString.cs
@@ -26,7 +26,7 @@ using System.Linq;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonErrorString : JsonSymbol
+    public sealed class JsonErrorString : JsonSymbol
     {
         /// <summary>
         /// Creates a <see cref="JsonErrorInfo"/> for unterminated strings.

--- a/Eutherion/Shared/Text/Json/JsonIntegerLiteralSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonIntegerLiteralSyntax.cs
@@ -28,13 +28,13 @@ namespace Eutherion.Text.Json
     /// </summary>
     public sealed class JsonIntegerLiteralSyntax : JsonValueSyntax
     {
-        public JsonSymbol IntegerToken { get; }
+        public JsonValue IntegerToken { get; }
 
         public BigInteger Value { get; }
 
         public override int Length => IntegerToken.Length;
 
-        public JsonIntegerLiteralSyntax(JsonSymbol integerToken, BigInteger value)
+        public JsonIntegerLiteralSyntax(JsonValue integerToken, BigInteger value)
         {
             IntegerToken = integerToken;
             Value = value;

--- a/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
@@ -28,7 +28,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Represents a single key-value pair in a <see cref="JsonMapSyntax"/>.
     /// </summary>
-    public sealed class JsonKeyValueSyntax
+    public sealed class JsonKeyValueSyntax : ISpan
     {
         /// <summary>
         /// Gets the syntax node containing the key of this <see cref="JsonKeyValueSyntax"/>.

--- a/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
@@ -41,9 +41,14 @@ namespace Eutherion.Text.Json
         public Maybe<JsonStringLiteralSyntax> ValidKey { get; }
 
         /// <summary>
-        /// Gets the list of syntax nodes containing the value of this <see cref="JsonKeyValueSyntax"/>.
+        /// Returns the first value node containing the value of this <see cref="JsonKeyValueSyntax"/>, if it was provided.
         /// </summary>
-        public ReadOnlyList<JsonMultiValueSyntax> ValueNodes { get; }
+        public Maybe<JsonMultiValueSyntax> FirstValueNode => ValueSectionNodes.Count > 0 ? ValueSectionNodes[0] : Maybe<JsonMultiValueSyntax>.Nothing;
+
+        /// <summary>
+        /// Gets the list of value section nodes separated by colon characters.
+        /// </summary>
+        public ReadOnlyList<JsonMultiValueSyntax> ValueSectionNodes { get; }
 
         private readonly int[] ValueNodePositions;
 
@@ -79,16 +84,16 @@ namespace Eutherion.Text.Json
             if (validKey.IsJust(out JsonStringLiteralSyntax validKeyNode)
                 && validKeyNode != keyNode.ValueNode.ContentNode) throw new ArgumentException(nameof(validKey));
 
-            ValueNodes = ReadOnlyList<JsonMultiValueSyntax>.Create(valueNodes);
+            ValueSectionNodes = ReadOnlyList<JsonMultiValueSyntax>.Create(valueNodes);
 
             int cumulativeLength = keyNode.Length;
-            ValueNodePositions = new int[ValueNodes.Count];
+            ValueNodePositions = new int[ValueSectionNodes.Count];
 
-            for (int i = 0; i < ValueNodes.Count; i++)
+            for (int i = 0; i < ValueSectionNodes.Count; i++)
             {
                 cumulativeLength += JsonColon.ColonLength;
                 ValueNodePositions[i] = cumulativeLength;
-                cumulativeLength += ValueNodes[i].Length;
+                cumulativeLength += ValueSectionNodes[i].Length;
             }
 
             Length = cumulativeLength;

--- a/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonKeyValueSyntax.cs
@@ -28,7 +28,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Represents a single key-value pair in a <see cref="JsonMapSyntax"/>.
     /// </summary>
-    public class JsonKeyValueSyntax
+    public sealed class JsonKeyValueSyntax
     {
         /// <summary>
         /// Gets the syntax node containing the key of this <see cref="JsonKeyValueSyntax"/>.

--- a/Eutherion/Shared/Text/Json/JsonListSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonListSyntax.cs
@@ -68,12 +68,12 @@ namespace Eutherion.Text.Json
 
             MissingSquareBracketClose = missingSquareBracketClose;
 
-            // This code assumes that JsonSquareBracketOpen.SquareBracketOpenLength == JsonComma.CommaLength.
-            // The first iteration should formally be SquareBracketOpenLength rather than CommaLength.
-            int cumulativeLength = 0;
             ListItemNodePositions = new int[ListItemNodes.Count];
+            int cumulativeLength = JsonSquareBracketOpen.SquareBracketOpenLength;
+            ListItemNodePositions[0] = cumulativeLength;
+            cumulativeLength += ListItemNodes[0].Length;
 
-            for (int i = 0; i < ListItemNodes.Count; i++)
+            for (int i = 1; i < ListItemNodes.Count; i++)
             {
                 cumulativeLength += JsonComma.CommaLength;
                 ListItemNodePositions[i] = cumulativeLength;

--- a/Eutherion/Shared/Text/Json/JsonListSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonListSyntax.cs
@@ -30,23 +30,23 @@ namespace Eutherion.Text.Json
     /// </summary>
     public sealed class JsonListSyntax : JsonValueSyntax
     {
-        public ReadOnlyList<JsonMultiValueSyntax> ElementNodes { get; }
+        public ReadOnlyList<JsonMultiValueSyntax> ListItemNodes { get; }
 
-        private readonly int[] ElementNodePositions;
+        private readonly int[] ListItemNodePositions;
 
         public bool MissingSquareBracketClose { get; }
 
         /// <summary>
-        /// Returns ElementNodes.Count, or one less if the last element is a JsonMissingValueSyntax.
+        /// Returns ListItemNodes.Count, or one less if the last element is a JsonMissingValueSyntax.
         /// </summary>
-        public int FilteredElementNodeCount
+        public int FilteredListItemNodeCount
         {
             get
             {
-                int count = ElementNodes.Count;
+                int count = ListItemNodes.Count;
 
                 // Discard last item if it's a missing value, so that a trailing comma is ignored.
-                if (ElementNodes[count - 1].ValueNode.ContentNode is JsonMissingValueSyntax)
+                if (ListItemNodes[count - 1].ValueNode.ContentNode is JsonMissingValueSyntax)
                 {
                     return count - 1;
                 }
@@ -57,13 +57,13 @@ namespace Eutherion.Text.Json
 
         public override int Length { get; }
 
-        public JsonListSyntax(IEnumerable<JsonMultiValueSyntax> elementNodes, bool missingSquareBracketClose)
+        public JsonListSyntax(IEnumerable<JsonMultiValueSyntax> listItemNodes, bool missingSquareBracketClose)
         {
-            ElementNodes = ReadOnlyList<JsonMultiValueSyntax>.Create(elementNodes);
+            ListItemNodes = ReadOnlyList<JsonMultiValueSyntax>.Create(listItemNodes);
 
-            if (ElementNodes.Count == 0)
+            if (ListItemNodes.Count == 0)
             {
-                throw new ArgumentException($"{nameof(elementNodes)} cannot be empty", nameof(elementNodes));
+                throw new ArgumentException($"{nameof(listItemNodes)} cannot be empty", nameof(listItemNodes));
             }
 
             MissingSquareBracketClose = missingSquareBracketClose;
@@ -71,13 +71,13 @@ namespace Eutherion.Text.Json
             // This code assumes that JsonSquareBracketOpen.SquareBracketOpenLength == JsonComma.CommaLength.
             // The first iteration should formally be SquareBracketOpenLength rather than CommaLength.
             int cumulativeLength = 0;
-            ElementNodePositions = new int[ElementNodes.Count];
+            ListItemNodePositions = new int[ListItemNodes.Count];
 
-            for (int i = 0; i < ElementNodes.Count; i++)
+            for (int i = 0; i < ListItemNodes.Count; i++)
             {
                 cumulativeLength += JsonComma.CommaLength;
-                ElementNodePositions[i] = cumulativeLength;
-                cumulativeLength += ElementNodes[i].Length;
+                ListItemNodePositions[i] = cumulativeLength;
+                cumulativeLength += ListItemNodes[i].Length;
             }
 
             if (!missingSquareBracketClose)
@@ -91,7 +91,7 @@ namespace Eutherion.Text.Json
         /// <summary>
         /// Gets the start position of an element node relative to the start position of this <see cref="JsonListSyntax"/>.
         /// </summary>
-        public int GetElementNodeStart(int index) => ElementNodePositions[index];
+        public int GetElementNodeStart(int index) => ListItemNodePositions[index];
 
         public override void Accept(JsonValueSyntaxVisitor visitor) => visitor.VisitListSyntax(this);
         public override TResult Accept<TResult>(JsonValueSyntaxVisitor<TResult> visitor) => visitor.VisitListSyntax(this);

--- a/Eutherion/Shared/Text/Json/JsonListSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonListSyntax.cs
@@ -68,15 +68,13 @@ namespace Eutherion.Text.Json
 
             MissingSquareBracketClose = missingSquareBracketClose;
 
-            ListItemNodePositions = new int[ListItemNodes.Count];
-            int cumulativeLength = JsonSquareBracketOpen.SquareBracketOpenLength;
-            ListItemNodePositions[0] = cumulativeLength;
-            cumulativeLength += ListItemNodes[0].Length;
+            ListItemNodePositions = new int[ListItemNodes.Count - 1];
+            int cumulativeLength = ListItemNodes[0].Length;
 
             for (int i = 1; i < ListItemNodes.Count; i++)
             {
                 cumulativeLength += JsonComma.CommaLength;
-                ListItemNodePositions[i] = cumulativeLength;
+                ListItemNodePositions[i - 1] = cumulativeLength;
                 cumulativeLength += ListItemNodes[i].Length;
             }
 
@@ -85,13 +83,13 @@ namespace Eutherion.Text.Json
                 cumulativeLength += JsonSquareBracketClose.SquareBracketCloseLength;
             }
 
-            Length = cumulativeLength;
+            Length = JsonSquareBracketOpen.SquareBracketOpenLength + cumulativeLength;
         }
 
         /// <summary>
         /// Gets the start position of an element node relative to the start position of this <see cref="JsonListSyntax"/>.
         /// </summary>
-        public int GetElementNodeStart(int index) => ListItemNodePositions[index];
+        public int GetElementNodeStart(int index) => JsonSquareBracketOpen.SquareBracketOpenLength + (index == 0 ? 0 : ListItemNodePositions[index - 1]);
 
         public override void Accept(JsonValueSyntaxVisitor visitor) => visitor.VisitListSyntax(this);
         public override TResult Accept<TResult>(JsonValueSyntaxVisitor<TResult> visitor) => visitor.VisitListSyntax(this);

--- a/Eutherion/Shared/Text/Json/JsonMapSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonMapSyntax.cs
@@ -49,12 +49,12 @@ namespace Eutherion.Text.Json
 
             MissingCurlyClose = missingCurlyClose;
 
-            // This code assumes that JsonCurlyOpen.CurlyOpenLength == JsonComma.CommaLength.
-            // The first iteration should be CurlyOpenLength rather than CommaLength.
-            int cumulativeLength = 0;
             KeyValueNodePositions = new int[KeyValueNodes.Count];
+            int cumulativeLength = JsonCurlyOpen.CurlyOpenLength;
+            KeyValueNodePositions[0] = cumulativeLength;
+            cumulativeLength += KeyValueNodes[0].Length;
 
-            for (int i = 0; i < KeyValueNodes.Count; i++)
+            for (int i = 1; i < KeyValueNodes.Count; i++)
             {
                 cumulativeLength += JsonComma.CommaLength;
                 KeyValueNodePositions[i] = cumulativeLength;

--- a/Eutherion/Shared/Text/Json/JsonMapSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonMapSyntax.cs
@@ -59,18 +59,15 @@ namespace Eutherion.Text.Json
                 {
                     var keyValueNode = KeyValueNodes[i];
 
-                    if (keyValueNode.ValidKey.IsJust(out JsonStringLiteralSyntax stringLiteral) && keyValueNode.ValueNodes.Count > 0)
+                    if (keyValueNode.ValidKey.IsJust(out JsonStringLiteralSyntax stringLiteral)
+                        && keyValueNode.FirstValueNode.IsJust(out JsonMultiValueSyntax multiValueNode)
+                        && !(multiValueNode.ValueNode.ContentNode is JsonMissingValueSyntax))
                     {
-                        JsonMultiValueSyntax multiValueNode = keyValueNode.ValueNodes[0];
-
                         // Only the first value can be valid, even if it's undefined.
-                        if (!(multiValueNode.ValueNode.ContentNode is JsonMissingValueSyntax))
-                        {
-                            int keyNodeStart = GetKeyValueNodeStart(i) + keyValueNode.KeyNode.ValueNode.BackgroundBefore.Length;
-                            int valueNodeStart = GetKeyValueNodeStart(i) + keyValueNode.GetValueNodeStart(0) + multiValueNode.ValueNode.BackgroundBefore.Length;
+                        int keyNodeStart = GetKeyValueNodeStart(i) + keyValueNode.KeyNode.ValueNode.BackgroundBefore.Length;
+                        int valueNodeStart = GetKeyValueNodeStart(i) + keyValueNode.GetValueNodeStart(0) + multiValueNode.ValueNode.BackgroundBefore.Length;
 
-                            yield return (keyNodeStart, stringLiteral, valueNodeStart, multiValueNode.ValueNode.ContentNode);
-                        }
+                        yield return (keyNodeStart, stringLiteral, valueNodeStart, multiValueNode.ValueNode.ContentNode);
                     }
                 }
             }

--- a/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
@@ -29,7 +29,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Contains a value node together with all value nodes and background that follow it.
     /// </summary>
-    public sealed class JsonMultiValueSyntax
+    public sealed class JsonMultiValueSyntax : ISpan
     {
         // This syntax is generated everywhere a single value is expected.
         // It is a parse error if zero values, or two or more values are given, the exception being

--- a/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
@@ -19,10 +19,8 @@
 **********************************************************************************/
 #endregion
 
-using Eutherion.Utils;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Eutherion.Text.Json
 {
@@ -87,7 +85,7 @@ namespace Eutherion.Text.Json
         /// <summary>
         /// Gets the non-empty list of value nodes.
         /// </summary>
-        public ReadOnlyList<JsonValueWithBackgroundSyntax> ValueNodes { get; }
+        public ReadOnlySpanList<JsonValueWithBackgroundSyntax> ValueNodes { get; }
 
         /// <summary>
         /// Gets the background after the value nodes.
@@ -97,7 +95,7 @@ namespace Eutherion.Text.Json
         /// <summary>
         /// Gets the length of the text span corresponding with this node.
         /// </summary>
-        public int Length { get; }
+        public int Length => ValueNodes.Length + BackgroundAfter.Length;
 
         /// <summary>
         /// Initializes a new instance of <see cref="JsonMultiValueSyntax"/>.
@@ -116,7 +114,7 @@ namespace Eutherion.Text.Json
         /// </exception>
         public JsonMultiValueSyntax(IEnumerable<JsonValueWithBackgroundSyntax> valueNodes, JsonBackgroundSyntax backgroundAfter)
         {
-            ValueNodes = ReadOnlyList<JsonValueWithBackgroundSyntax>.Create(valueNodes);
+            ValueNodes = ReadOnlySpanList<JsonValueWithBackgroundSyntax>.Create(valueNodes);
 
             if (ValueNodes.Count == 0)
             {
@@ -124,7 +122,6 @@ namespace Eutherion.Text.Json
             }
 
             BackgroundAfter = backgroundAfter ?? throw new ArgumentNullException(nameof(backgroundAfter));
-            Length = ValueNodes.Sum(x => x.Length) + BackgroundAfter.Length;
         }
     }
 }

--- a/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonMultiValueSyntax.cs
@@ -27,7 +27,7 @@ using System.Linq;
 namespace Eutherion.Text.Json
 {
     /// <summary>
-    /// Contains a value node together with all value nodes and background that follow it.
+    /// Contains one or more value nodes together with all background syntax that precedes and follows it.
     /// </summary>
     public sealed class JsonMultiValueSyntax : ISpan
     {
@@ -42,37 +42,37 @@ namespace Eutherion.Text.Json
         //
         // []            - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 0
         //                 ValueNode.ContentNode is JsonMissingValueSyntax
-        //                 IgnoredNodes.Count == 0
+        //                 ValueNodes.Count == 1
         //                 BackgroundAfter.BackgroundSymbols.Count == 0
         //
         // [/**/]        - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 1  (one JsonComment)
         //                 ValueNode.ContentNode is JsonMissingValueSyntax
-        //                 IgnoredNodes.Count == 0
+        //                 ValueNodes.Count == 1
         //                 BackgroundAfter.BackgroundSymbols.Count == 0
         //
         // [/**/0]       - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 1
         //                 ValueNode.ContentNode is JsonIntegerLiteralSyntax
-        //                 IgnoredNodes.Count == 0
+        //                 ValueNodes.Count == 1
         //                 BackgroundAfter.BackgroundSymbols.Count == 0
         //
         // [/**/0/**/]   - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 1
         //                 ValueNode.ContentNode is JsonIntegerLiteralSyntax
-        //                 IgnoredNodes.Count == 0
+        //                 ValueNodes.Count == 1
         //                 BackgroundAfter.BackgroundSymbols.Count == 1
         //
         // [0 ]          - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 0
         //                 ValueNode.ContentNode is JsonIntegerLiteralSyntax
-        //                 IgnoredNodes.Count == 0
+        //                 ValueNodes.Count == 1
         //                 BackgroundAfter.BackgroundSymbols.Count == 1             (one JsonWhitespace)
         //
         // [ 0 false ]   - ValueNode.BackgroundBefore.BackgroundSymbols.Count == 1
         //                 ValueNode.ContentNode is JsonIntegerLiteralSyntax
-        //                 IgnoredNodes.Count == 1
-        //                 IgnoredNodes[0].BackgroundSymbols.Count == 1
-        //                 IgnoredNodes[0].ContentNode is JsonBooleanLiteralSyntax
+        //                 ValueNodes.Count == 2
+        //                 ValueNodes[1].BackgroundSymbols.Count == 1
+        //                 ValueNodes[1].ContentNode is JsonBooleanLiteralSyntax
         //                 BackgroundAfter.BackgroundSymbols.Count == 1
         //
-        // Only the first ValueNode can be JsonMissingValueSyntax, and if it is, IgnoredNodes.Count is always 0,
+        // Only the first ValueNode (ValueNodes[0]) can be JsonMissingValueSyntax, and if it is, ValueNodes.Count is always 1,
         // ValueNode.BackgroundBefore may still be non-empty, and BackgroundAfter is always empty.
         //
         // The main reason this structure exists like this is because there needs to be a place where
@@ -82,12 +82,12 @@ namespace Eutherion.Text.Json
         /// Gets the syntax node containing the first value.
         /// Is JsonMissingValueSyntax if a value was expected but none given. (E.g. in "[0,,2]", middle element.)
         /// </summary>
-        public JsonValueWithBackgroundSyntax ValueNode { get; }
+        public JsonValueWithBackgroundSyntax ValueNode => ValueNodes[0];
 
         /// <summary>
-        /// Gets the list of ignored value nodes after the first.
+        /// Gets the non-empty list of value nodes.
         /// </summary>
-        public ReadOnlyList<JsonValueWithBackgroundSyntax> IgnoredNodes { get; }
+        public ReadOnlyList<JsonValueWithBackgroundSyntax> ValueNodes { get; }
 
         /// <summary>
         /// Gets the background after the value nodes.
@@ -102,27 +102,29 @@ namespace Eutherion.Text.Json
         /// <summary>
         /// Initializes a new instance of <see cref="JsonMultiValueSyntax"/>.
         /// </summary>
-        /// <param name="valueNode">
-        /// The syntax node containing the first value.
-        /// </param>
-        /// <param name="ignoredNodes">
-        /// The list of ignored value nodes after the first.
+        /// <param name="valueNodes">
+        /// The non-empty list of value nodes.
         /// </param>
         /// <param name="backgroundAfter">
         /// The background after the value nodes.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="valueNode"/> and/or <paramref name="ignoredNodes"/> and/or <paramref name="backgroundAfter"/> are null.
+        /// <paramref name="valueNodes"/> and/or <paramref name="backgroundAfter"/> are null.
         /// </exception>
-        public JsonMultiValueSyntax(
-            JsonValueWithBackgroundSyntax valueNode,
-            IEnumerable<JsonValueWithBackgroundSyntax> ignoredNodes,
-            JsonBackgroundSyntax backgroundAfter)
+        /// <exception cref="ArgumentException">
+        /// <paramref name="valueNodes"/> is an empty enumeration.
+        /// </exception>
+        public JsonMultiValueSyntax(IEnumerable<JsonValueWithBackgroundSyntax> valueNodes, JsonBackgroundSyntax backgroundAfter)
         {
-            ValueNode = valueNode ?? throw new ArgumentNullException(nameof(valueNode));
-            IgnoredNodes = ReadOnlyList<JsonValueWithBackgroundSyntax>.Create(ignoredNodes);
+            ValueNodes = ReadOnlyList<JsonValueWithBackgroundSyntax>.Create(valueNodes);
+
+            if (ValueNodes.Count == 0)
+            {
+                throw new ArgumentException($"{nameof(valueNodes)} cannot be empty", nameof(valueNodes));
+            }
+
             BackgroundAfter = backgroundAfter ?? throw new ArgumentNullException(nameof(backgroundAfter));
-            Length = ValueNode.Length + IgnoredNodes.Sum(x => x.Length) + BackgroundAfter.Length;
+            Length = ValueNodes.Sum(x => x.Length) + BackgroundAfter.Length;
         }
     }
 }

--- a/Eutherion/Shared/Text/Json/JsonParser.cs
+++ b/Eutherion/Shared/Text/Json/JsonParser.cs
@@ -52,7 +52,7 @@ namespace Eutherion.Text.Json
 
         private void ShiftToNextForegroundToken()
         {
-            // Skip comments until encountering something meaningful.
+            // Skip background until encountering something meaningful.
             for (; ; )
             {
                 CurrentToken = Tokens.MoveNext() ? Tokens.Current : null;
@@ -82,6 +82,7 @@ namespace Eutherion.Text.Json
 
             for (; ; )
             {
+                // Save CurrentLength for error reporting before parsing the key.
                 int keyStart = CurrentLength;
                 JsonMultiValueSyntax multiKeyNode = ParseMultiValue(JsonErrorCode.MultiplePropertyKeys);
                 JsonValueSyntax parsedKeyNode = multiKeyNode.ValueNode.ContentNode;
@@ -318,6 +319,7 @@ namespace Eutherion.Text.Json
                 bool unprocessedToken;
                 if (CurrentToken.HasErrors)
                 {
+                    // JsonErrorString, JsonUnknownSymbol
                     currentNode = new JsonUndefinedValueSyntax(CurrentToken);
                     unprocessedToken = false;
                 }

--- a/Eutherion/Shared/Text/Json/JsonParser.cs
+++ b/Eutherion/Shared/Text/Json/JsonParser.cs
@@ -128,6 +128,7 @@ namespace Eutherion.Text.Json
 
                 // Reuse keyValueSyntaxBuilder.
                 keyValueSyntaxBuilder.Clear();
+                keyValueSyntaxBuilder.Add(multiKeyNode);
 
                 // Keep parsing multi-values until encountering a non ':'.
                 bool gotColon = false;
@@ -152,10 +153,7 @@ namespace Eutherion.Text.Json
                 }
 
                 // One key-value section done.
-                var jsonKeyValueSyntax = new JsonKeyValueSyntax(
-                    multiKeyNode,
-                    validKey,
-                    keyValueSyntaxBuilder);
+                var jsonKeyValueSyntax = new JsonKeyValueSyntax(validKey, keyValueSyntaxBuilder);
 
                 mapBuilder.Add(jsonKeyValueSyntax);
 
@@ -177,8 +175,8 @@ namespace Eutherion.Text.Json
 
                     // Report missing value error from being reported if all value sections are empty.
                     // Example: { "key1":: 2, "key2": , }
-                    // The first section does not report a missing value, the second section does.
-                    if (jsonKeyValueSyntax.ValueSectionNodes.All(x => x.ValueNode.ContentNode is JsonMissingValueSyntax))
+                    // Skip the fist value section, it contains the key node.
+                    if (jsonKeyValueSyntax.ValueSectionNodes.Skip(1).All(x => x.ValueNode.ContentNode is JsonMissingValueSyntax))
                     {
                         Errors.Add(new JsonErrorInfo(
                             JsonErrorCode.MissingValue,

--- a/Eutherion/Shared/Text/Json/JsonParser.cs
+++ b/Eutherion/Shared/Text/Json/JsonParser.cs
@@ -44,7 +44,7 @@ namespace Eutherion.Text.Json
         // Used for parse error reporting.
         private int CurrentLength;
 
-        public JsonParser(string json)
+        private JsonParser(string json)
         {
             Json = json ?? throw new ArgumentNullException(nameof(json));
             Tokens = JsonTokenizer.TokenizeAll(json).GetEnumerator();
@@ -372,7 +372,7 @@ namespace Eutherion.Text.Json
             }
         }
 
-        public JsonMultiValueSyntax TryParse(out List<JsonErrorInfo> errors)
+        private JsonMultiValueSyntax TryParse(out List<JsonErrorInfo> errors)
         {
             JsonMultiValueSyntax multiValueNode = ParseMultiValue(JsonErrorCode.ExpectedEof);
 
@@ -388,5 +388,8 @@ namespace Eutherion.Text.Json
 
             return multiValueNode;
         }
+
+        public static JsonMultiValueSyntax TryParse(string json, out List<JsonErrorInfo> errors)
+            => new JsonParser(json).TryParse(out errors);
     }
 }

--- a/Eutherion/Shared/Text/Json/JsonParser.cs
+++ b/Eutherion/Shared/Text/Json/JsonParser.cs
@@ -178,7 +178,7 @@ namespace Eutherion.Text.Json
                     // Report missing value error from being reported if all value sections are empty.
                     // Example: { "key1":: 2, "key2": , }
                     // The first section does not report a missing value, the second section does.
-                    if (jsonKeyValueSyntax.ValueNodes.All(x => x.ValueNode.ContentNode is JsonMissingValueSyntax))
+                    if (jsonKeyValueSyntax.ValueSectionNodes.All(x => x.ValueNode.ContentNode is JsonMissingValueSyntax))
                     {
                         Errors.Add(new JsonErrorInfo(
                             JsonErrorCode.MissingValue,

--- a/Eutherion/Shared/Text/Json/JsonSquareBracketClose.cs
+++ b/Eutherion/Shared/Text/Json/JsonSquareBracketClose.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonSquareBracketClose : JsonSymbol
+    public sealed class JsonSquareBracketClose : JsonSymbol
     {
         public const char SquareBracketCloseCharacter = ']';
         public const int SquareBracketCloseLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonSquareBracketOpen.cs
+++ b/Eutherion/Shared/Text/Json/JsonSquareBracketOpen.cs
@@ -21,7 +21,7 @@
 
 namespace Eutherion.Text.Json
 {
-    public class JsonSquareBracketOpen : JsonSymbol
+    public sealed class JsonSquareBracketOpen : JsonSymbol
     {
         public const char SquareBracketOpenCharacter = '[';
         public const int SquareBracketOpenLength = 1;

--- a/Eutherion/Shared/Text/Json/JsonString.cs
+++ b/Eutherion/Shared/Text/Json/JsonString.cs
@@ -24,7 +24,7 @@ using System.Runtime.CompilerServices;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonString : JsonSymbol
+    public sealed class JsonString : JsonSymbol
     {
         public const char QuoteCharacter = '"';
         public const char EscapeCharacter = '\\';

--- a/Eutherion/Shared/Text/Json/JsonSymbol.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbol.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace Eutherion.Text.Json
 {
-    public abstract class JsonSymbol
+    public abstract class JsonSymbol : ISpan
     {
         public virtual bool IsBackground => false;
         public virtual bool IsValueStartSymbol => false;

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -164,7 +164,7 @@ namespace Eutherion.Text.Json
             private JsonSymbol current;
             private bool comma;
             private IEnumerator<JsonMultiValueSyntax> listItemEnumerator;
-            private IEnumerator<JsonSymbol> elementValueEnumerator;
+            private IEnumerator<JsonSymbol> listItemValueEnumerator;
             private Func<bool> currentMoveNext;
 
             private bool SquareBracketOpenMoveNext()
@@ -179,7 +179,7 @@ namespace Eutherion.Text.Json
             {
                 if (listItemEnumerator.MoveNext())
                 {
-                    elementValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(listItemEnumerator.Current);
+                    listItemValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(listItemEnumerator.Current);
                     currentMoveNext = ElementNodeValueMoveNext;
 
                     if (comma)
@@ -207,9 +207,9 @@ namespace Eutherion.Text.Json
 
             private bool ElementNodeValueMoveNext()
             {
-                if (elementValueEnumerator.MoveNext())
+                if (listItemValueEnumerator.MoveNext())
                 {
-                    current = elementValueEnumerator.Current;
+                    current = listItemValueEnumerator.Current;
                     return true;
                 }
 

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -28,12 +28,6 @@ namespace Eutherion.Text.Json
 {
     public class JsonSymbolEnumerator : IEnumerable<JsonSymbol>
     {
-        // Originally I tried to use yield return expressions but it turns out that the compiler
-        // does not generate an entirely correct state machine from it in this case. It has
-        // trouble with JsonComma.Value and refuses to yield return it more than once inside
-        // the loop over the elements of an object or array, causing syntax highlighting to skew.
-        // So yeah, this is an implementation by hand.
-
         private class JsonSyntaxNodeWithBackgroundBeforeEnumerator : IEnumerator<JsonSymbol>
         {
             private readonly JsonValueWithBackgroundSyntax jsonSyntaxNodeWithBackgroundBefore;
@@ -150,15 +144,14 @@ namespace Eutherion.Text.Json
             }
 
             private JsonSymbol current;
-            private bool comma;
-            private IEnumerator<JsonMultiValueSyntax> listItemEnumerator;
+            private IEnumerator<Union<JsonMultiValueSyntax, JsonComma>> listItemEnumerator;
             private IEnumerator<JsonSymbol> listItemValueEnumerator;
             private Func<bool> currentMoveNext;
 
             private bool SquareBracketOpenMoveNext()
             {
                 current = JsonSquareBracketOpen.Value;
-                listItemEnumerator = jsonListSyntax.ListItemNodes.GetEnumerator();
+                listItemEnumerator = jsonListSyntax.ListItemNodes.AllElements.GetEnumerator();
                 currentMoveNext = ElementsMoveNext;
                 return true;
             }
@@ -167,20 +160,22 @@ namespace Eutherion.Text.Json
             {
                 if (listItemEnumerator.MoveNext())
                 {
-                    listItemValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(listItemEnumerator.Current);
-                    currentMoveNext = ElementNodeValueMoveNext;
+                    bool isComma = false;
 
-                    if (comma)
-                    {
-                        current = JsonComma.Value;
-                        return true;
-                    }
-                    else
-                    {
-                        comma = true;
-                    }
+                    listItemEnumerator.Current.Match(
+                        whenOption1: listItemNode =>
+                        {
+                            listItemValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(listItemNode);
+                            currentMoveNext = ListItemValueMoveNext;
+                        },
+                        whenOption2: comma =>
+                        {
+                            current = comma;
+                            isComma = true;
+                        });
 
-                    return ElementNodeValueMoveNext();
+                    // When encountering a separator, just re-enter this MoveNext method on the next iteration.
+                    return isComma || ListItemValueMoveNext();
                 }
 
                 if (!jsonListSyntax.MissingSquareBracketClose)
@@ -193,7 +188,7 @@ namespace Eutherion.Text.Json
                 return false;
             }
 
-            private bool ElementNodeValueMoveNext()
+            private bool ListItemValueMoveNext()
             {
                 if (listItemValueEnumerator.MoveNext())
                 {
@@ -224,17 +219,15 @@ namespace Eutherion.Text.Json
             }
 
             private JsonSymbol current;
-            private bool comma;
-            private JsonKeyValueSyntax keyValueNode;
-            private IEnumerator<JsonKeyValueSyntax> keyValueNodeEnumerator;
-            private IEnumerator<JsonMultiValueSyntax> valueSectionNodesEnumerator;
+            private IEnumerator<Union<JsonKeyValueSyntax, JsonComma>> keyValueNodeEnumerator;
+            private IEnumerator<Union<JsonMultiValueSyntax, JsonColon>> valueSectionNodesEnumerator;
             private IEnumerator<JsonSymbol> multiValueEnumerator;
             private Func<bool> currentMoveNext;
 
             private bool CurlyOpenMoveNext()
             {
                 current = JsonCurlyOpen.Value;
-                keyValueNodeEnumerator = jsonMapSyntax.KeyValueNodes.GetEnumerator();
+                keyValueNodeEnumerator = jsonMapSyntax.KeyValueNodes.AllElements.GetEnumerator();
                 currentMoveNext = KeyValueMoveNext;
                 return true;
             }
@@ -243,18 +236,22 @@ namespace Eutherion.Text.Json
             {
                 if (keyValueNodeEnumerator.MoveNext())
                 {
-                    keyValueNode = keyValueNodeEnumerator.Current;
-                    multiValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(keyValueNode.KeyNode);
-                    currentMoveNext = KeyNodeMoveNext;
+                    bool isComma = false;
 
-                    if (comma)
-                    {
-                        current = JsonComma.Value;
-                        return true;
-                    }
+                    keyValueNodeEnumerator.Current.Match(
+                        whenOption1: keyValueNode =>
+                        {
+                            valueSectionNodesEnumerator = keyValueNode.ValueSectionNodes.AllElements.GetEnumerator();
+                            currentMoveNext = ValueNodesMoveNext;
+                        },
+                        whenOption2: comma =>
+                        {
+                            current = comma;
+                            isComma = true;
+                        });
 
-                    comma = true;
-                    return KeyNodeMoveNext();
+                    // When encountering a separator, just re-enter this MoveNext method on the next iteration.
+                    return isComma || ValueNodesMoveNext();
                 }
 
                 if (!jsonMapSyntax.MissingCurlyClose)
@@ -267,28 +264,26 @@ namespace Eutherion.Text.Json
                 return false;
             }
 
-            private bool KeyNodeMoveNext()
-            {
-                if (multiValueEnumerator.MoveNext())
-                {
-                    current = multiValueEnumerator.Current;
-                    return true;
-                }
-
-                valueSectionNodesEnumerator = keyValueNode.ValueSectionNodes.GetEnumerator();
-                valueSectionNodesEnumerator.MoveNext(); // Skip the key node.
-                currentMoveNext = ValueNodesMoveNext;
-                return ValueNodesMoveNext();
-            }
-
             private bool ValueNodesMoveNext()
             {
                 if (valueSectionNodesEnumerator.MoveNext())
                 {
-                    current = JsonColon.Value;
-                    multiValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(valueSectionNodesEnumerator.Current);
-                    currentMoveNext = ValueNodeMoveNext;
-                    return true;
+                    bool isColon = false;
+
+                    valueSectionNodesEnumerator.Current.Match(
+                        whenOption1: valueSectionNode =>
+                        {
+                            multiValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(valueSectionNode);
+                            currentMoveNext = ValueNodeMoveNext;
+                        },
+                        whenOption2: colon =>
+                        {
+                            current = colon;
+                            isColon = true;
+                        });
+
+                    // When encountering a separator, just re-enter this MoveNext method on the next iteration.
+                    return isColon || ValueNodeMoveNext();
                 }
 
                 return KeyValueMoveNext();

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -87,34 +87,22 @@ namespace Eutherion.Text.Json
             public JsonMultiValueSyntaxNodeEnumerator(JsonMultiValueSyntax jsonMultiValueSyntaxNode)
             {
                 this.jsonMultiValueSyntaxNode = jsonMultiValueSyntaxNode;
-                currentEnumerator = new JsonSyntaxNodeWithBackgroundBeforeEnumerator(jsonMultiValueSyntaxNode.ValueNode);
-                currentMoveNext = NodeWithBackgroundMoveNext;
+                valueNodesEnumerator = jsonMultiValueSyntaxNode.ValueNodes.GetEnumerator();
+                currentMoveNext = ValueNodesMoveNext;
             }
 
             private JsonSymbol current;
-            private IEnumerator<JsonValueWithBackgroundSyntax> ignoredNodesEnumerator;
+            private readonly IEnumerator<JsonValueWithBackgroundSyntax> valueNodesEnumerator;
             private IEnumerator<JsonSymbol> currentEnumerator;
             private Func<bool> currentMoveNext;
 
-            private bool NodeWithBackgroundMoveNext()
+            private bool ValueNodesMoveNext()
             {
-                if (currentEnumerator.MoveNext())
+                if (valueNodesEnumerator.MoveNext())
                 {
-                    current = currentEnumerator.Current;
-                    return true;
-                }
-
-                ignoredNodesEnumerator = jsonMultiValueSyntaxNode.IgnoredNodes.GetEnumerator();
-                return IgnoredNodesMoveNext();
-            }
-
-            private bool IgnoredNodesMoveNext()
-            {
-                if (ignoredNodesEnumerator.MoveNext())
-                {
-                    currentEnumerator = new JsonSyntaxNodeWithBackgroundBeforeEnumerator(ignoredNodesEnumerator.Current);
-                    currentMoveNext = IgnoredNodeWithBackgroundMoveNext;
-                    return IgnoredNodeWithBackgroundMoveNext();
+                    currentEnumerator = new JsonSyntaxNodeWithBackgroundBeforeEnumerator(valueNodesEnumerator.Current);
+                    currentMoveNext = ValueNodeWithBackgroundMoveNext;
+                    return ValueNodeWithBackgroundMoveNext();
                 }
 
                 currentEnumerator = jsonMultiValueSyntaxNode.BackgroundAfter.BackgroundSymbols.GetEnumerator();
@@ -122,7 +110,7 @@ namespace Eutherion.Text.Json
                 return BackgroundAfterMoveNext();
             }
 
-            private bool IgnoredNodeWithBackgroundMoveNext()
+            private bool ValueNodeWithBackgroundMoveNext()
             {
                 if (currentEnumerator.MoveNext())
                 {
@@ -130,7 +118,7 @@ namespace Eutherion.Text.Json
                     return true;
                 }
 
-                return IgnoredNodesMoveNext();
+                return ValueNodesMoveNext();
             }
 
             private bool BackgroundAfterMoveNext()

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -191,23 +191,23 @@ namespace Eutherion.Text.Json
 
             private JsonSymbol current;
             private bool comma;
-            private IEnumerator<JsonMultiValueSyntax> elementEnumerator;
+            private IEnumerator<JsonMultiValueSyntax> listItemEnumerator;
             private IEnumerator<JsonSymbol> elementValueEnumerator;
             private Func<bool> currentMoveNext;
 
             private bool SquareBracketOpenMoveNext()
             {
                 current = JsonSquareBracketOpen.Value;
-                elementEnumerator = jsonListSyntax.ElementNodes.GetEnumerator();
+                listItemEnumerator = jsonListSyntax.ListItemNodes.GetEnumerator();
                 currentMoveNext = ElementsMoveNext;
                 return true;
             }
 
             private bool ElementsMoveNext()
             {
-                if (elementEnumerator.MoveNext())
+                if (listItemEnumerator.MoveNext())
                 {
-                    elementValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(elementEnumerator.Current);
+                    elementValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(listItemEnumerator.Current);
                     currentMoveNext = ElementNodeValueMoveNext;
 
                     if (comma)

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -227,7 +227,7 @@ namespace Eutherion.Text.Json
             private bool comma;
             private JsonKeyValueSyntax keyValueNode;
             private IEnumerator<JsonKeyValueSyntax> keyValueNodeEnumerator;
-            private IEnumerator<JsonMultiValueSyntax> valueNodeEnumerator;
+            private IEnumerator<JsonMultiValueSyntax> valueSectionNodesEnumerator;
             private IEnumerator<JsonSymbol> multiValueEnumerator;
             private Func<bool> currentMoveNext;
 
@@ -275,17 +275,17 @@ namespace Eutherion.Text.Json
                     return true;
                 }
 
-                valueNodeEnumerator = keyValueNode.ValueNodes.GetEnumerator();
+                valueSectionNodesEnumerator = keyValueNode.ValueSectionNodes.GetEnumerator();
                 currentMoveNext = ValueNodesMoveNext;
                 return ValueNodesMoveNext();
             }
 
             private bool ValueNodesMoveNext()
             {
-                if (valueNodeEnumerator.MoveNext())
+                if (valueSectionNodesEnumerator.MoveNext())
                 {
                     current = JsonColon.Value;
-                    multiValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(valueNodeEnumerator.Current);
+                    multiValueEnumerator = new JsonMultiValueSyntaxNodeEnumerator(valueSectionNodesEnumerator.Current);
                     currentMoveNext = ValueNodeMoveNext;
                     return true;
                 }

--- a/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
+++ b/Eutherion/Shared/Text/Json/JsonSymbolEnumerator.cs
@@ -276,6 +276,7 @@ namespace Eutherion.Text.Json
                 }
 
                 valueSectionNodesEnumerator = keyValueNode.ValueSectionNodes.GetEnumerator();
+                valueSectionNodesEnumerator.MoveNext(); // Skip the key node.
                 currentMoveNext = ValueNodesMoveNext;
                 return ValueNodesMoveNext();
             }

--- a/Eutherion/Shared/Text/Json/JsonUnknownSymbol.cs
+++ b/Eutherion/Shared/Text/Json/JsonUnknownSymbol.cs
@@ -24,7 +24,7 @@ using System.Collections.Generic;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonUnknownSymbol : JsonSymbol
+    public sealed class JsonUnknownSymbol : JsonSymbol
     {
         public const int UnknownSymbolLength = 1;
 

--- a/Eutherion/Shared/Text/Json/JsonUnterminatedMultiLineComment.cs
+++ b/Eutherion/Shared/Text/Json/JsonUnterminatedMultiLineComment.cs
@@ -24,7 +24,7 @@ using System.Collections.Generic;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonUnterminatedMultiLineComment : JsonSymbol
+    public sealed class JsonUnterminatedMultiLineComment : JsonSymbol
     {
         /// <summary>
         /// Creates a <see cref="JsonErrorInfo"/> for unterminated multiline comments.

--- a/Eutherion/Shared/Text/Json/JsonValue.cs
+++ b/Eutherion/Shared/Text/Json/JsonValue.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonValue : JsonSymbol
+    public sealed class JsonValue : JsonSymbol
     {
         public const int FalseSymbolLength = 5;
         public const int TrueSymbolLength = 4;

--- a/Eutherion/Shared/Text/Json/JsonValueSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonValueSyntax.cs
@@ -24,7 +24,7 @@ namespace Eutherion.Text.Json
     /// <summary>
     /// Represents a node in an abstract json syntax tree.
     /// </summary>
-    public abstract class JsonValueSyntax
+    public abstract class JsonValueSyntax : ISpan
     {
         /// <summary>
         /// Gets the length of the text span corresponding with this node.

--- a/Eutherion/Shared/Text/Json/JsonValueWithBackgroundSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonValueWithBackgroundSyntax.cs
@@ -27,7 +27,7 @@ namespace Eutherion.Text.Json
     /// Represents a <see cref="JsonValueSyntax"/> node together with the background symbols
     /// which directly precede it in an abstract json syntax tree.
     /// </summary>
-    public class JsonValueWithBackgroundSyntax
+    public sealed class JsonValueWithBackgroundSyntax
     {
         /// <summary>
         /// Gets the background symbols which directly precede the content value node.

--- a/Eutherion/Shared/Text/Json/JsonValueWithBackgroundSyntax.cs
+++ b/Eutherion/Shared/Text/Json/JsonValueWithBackgroundSyntax.cs
@@ -27,7 +27,7 @@ namespace Eutherion.Text.Json
     /// Represents a <see cref="JsonValueSyntax"/> node together with the background symbols
     /// which directly precede it in an abstract json syntax tree.
     /// </summary>
-    public sealed class JsonValueWithBackgroundSyntax
+    public sealed class JsonValueWithBackgroundSyntax : ISpan
     {
         /// <summary>
         /// Gets the background symbols which directly precede the content value node.

--- a/Eutherion/Shared/Text/Json/JsonWhitespace.cs
+++ b/Eutherion/Shared/Text/Json/JsonWhitespace.cs
@@ -23,7 +23,7 @@ using System;
 
 namespace Eutherion.Text.Json
 {
-    public class JsonWhitespace : JsonSymbol
+    public sealed class JsonWhitespace : JsonSymbol
     {
         /// <summary>
         /// Maximum length before new <see cref="JsonWhitespace"/> instances are always newly allocated.

--- a/Eutherion/Shared/Text/ReadOnlySeparatedSpanList.cs
+++ b/Eutherion/Shared/Text/ReadOnlySeparatedSpanList.cs
@@ -48,6 +48,8 @@ namespace Eutherion.Text
 
             public override IEnumerator<TSpan> GetEnumerator() => EmptyEnumerator<TSpan>.Instance;
 
+            public override IEnumerable<Union<TSpan, TSeparator>> AllElements => default(EmptyEnumerable<Union<TSpan, TSeparator>>);
+
             public override int GetElementOffset(int index) => throw new IndexOutOfRangeException();
         }
 
@@ -68,6 +70,8 @@ namespace Eutherion.Text
             public override int Count => 1;
 
             public override IEnumerator<TSpan> GetEnumerator() => new SingleElementEnumerator<TSpan>(element);
+
+            public override IEnumerable<Union<TSpan, TSeparator>> AllElements => new SingleElementEnumerable<Union<TSpan, TSeparator>>(element);
 
             public override int GetElementOffset(int index) => index == 0 ? 0 : throw new IndexOutOfRangeException();
         }
@@ -106,6 +110,20 @@ namespace Eutherion.Text
             public override int Count => array.Length;
 
             public override IEnumerator<TSpan> GetEnumerator() => ((ICollection<TSpan>)array).GetEnumerator();
+
+            public override IEnumerable<Union<TSpan, TSeparator>> AllElements
+            {
+                get
+                {
+                    yield return array[0];
+
+                    for (int i = 1; i < array.Length; i++)
+                    {
+                        yield return separator;
+                        yield return array[i];
+                    }
+                }
+            }
 
             public override int GetElementOffset(int index) => index == 0 ? 0 : arrayElementOffsets[index - 1];
         }
@@ -192,5 +210,13 @@ namespace Eutherion.Text
         /// <paramref name="index"/>is less than 0 or greater than or equal to <see cref="Count"/>.
         /// </exception>
         public abstract int GetElementOffset(int index);
+
+        /// <summary>
+        /// Enumerates all elements of the list, including separators.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="IEnumerable{T}"/> that enumerates all elements of the list, including separators.
+        /// </returns>
+        public abstract IEnumerable<Union<TSpan, TSeparator>> AllElements { get; }
     }
 }

--- a/Eutherion/Shared/Text/ReadOnlySeparatedSpanList.cs
+++ b/Eutherion/Shared/Text/ReadOnlySeparatedSpanList.cs
@@ -1,0 +1,172 @@
+﻿#region License
+/*********************************************************************************
+ * ReadOnlySeparatedSpanList.cs
+ *
+ * Copyright (c) 2004-2019 Henk Nicolai
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+**********************************************************************************/
+#endregion
+
+using Eutherion.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Eutherion.Text
+{
+    /// <summary>
+    /// Represents a read-only list of spanned elements that can be accessed by index and that are separated by a separator.
+    /// </summary>
+    /// <typeparam name="TSpan">
+    /// The type of spanned elements in the read-only list.
+    /// </typeparam>
+    /// <typeparam name="TSeparator">
+    /// The type of separator between successive elements in the read-only list.
+    /// </typeparam>
+    public abstract class ReadOnlySeparatedSpanList<TSpan, TSeparator> : IReadOnlyList<TSpan>, ISpan where TSpan : ISpan where TSeparator : ISpan
+    {
+        private class ZeroElements : ReadOnlySeparatedSpanList<TSpan, TSeparator>
+        {
+            public override int Length => 0;
+
+            public override TSpan this[int index] => throw new IndexOutOfRangeException();
+
+            public override int Count => 0;
+
+            public override IEnumerator<TSpan> GetEnumerator() => EmptyEnumerator<TSpan>.Instance;
+        }
+
+        private class OneElement : ReadOnlySeparatedSpanList<TSpan, TSeparator>
+        {
+            private readonly TSpan element;
+
+            public OneElement(TSpan source)
+            {
+                if (source == null) throw new ArgumentException(nameof(source));
+                element = source;
+            }
+
+            public override int Length => element.Length;
+
+            public override TSpan this[int index] => index == 0 ? element : throw new IndexOutOfRangeException();
+
+            public override int Count => 1;
+
+            public override IEnumerator<TSpan> GetEnumerator() => new SingleElementEnumerator<TSpan>(element);
+        }
+
+        private class TwoOrMoreElements : ReadOnlySeparatedSpanList<TSpan, TSeparator>
+        {
+            private readonly TSpan[] array;
+            private readonly TSeparator separator;
+
+            public TwoOrMoreElements(TSpan[] source, TSeparator separator)
+            {
+                if (source[0] == null) throw new ArgumentException(nameof(source));
+                int length = source[0].Length;
+                int separatorLength = separator.Length;
+
+                for (int i = 1; i < source.Length; i++)
+                {
+                    TSpan arrayElement = source[i];
+                    if (arrayElement == null) throw new ArgumentException(nameof(source));
+                    length += separatorLength;
+                    length += arrayElement.Length;
+                }
+
+                array = source;
+                this.separator = separator;
+                Length = length;
+            }
+
+            public override int Length { get; }
+
+            public override TSpan this[int index] => array[index];
+
+            public override int Count => array.Length;
+
+            public override IEnumerator<TSpan> GetEnumerator() => ((ICollection<TSpan>)array).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets the empty <see cref="ReadOnlySeparatedSpanList{TSpan, TSeparator}"/>.
+        /// </summary>
+        public static readonly ReadOnlySeparatedSpanList<TSpan, TSeparator> Empty = new ZeroElements();
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ReadOnlySeparatedSpanList{TSpan, TSeparator}"/>.
+        /// </summary>
+        /// <param name="source">
+        /// The elements of the list.
+        /// </param>
+        /// <param name="separator">
+        /// The separator between successive elements of the list.
+        /// </param>
+        /// <returns>
+        /// The initialized <see cref="ReadOnlySeparatedSpanList{TSpan, TSeparator}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> and/or <paramref name="separator"/> are null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One or more elements in <paramref name="source"/> are null.
+        /// </exception>
+        public static ReadOnlySeparatedSpanList<TSpan, TSeparator> Create(IEnumerable<TSpan> source, TSeparator separator)
+        {
+            var array = source.ToArrayEx();
+            if (separator == null) throw new ArgumentNullException(nameof(separator));
+            if (array.Length == 0) return Empty;
+            if (array.Length == 1) return new OneElement(array[0]);
+            return new TwoOrMoreElements(array, separator);
+        }
+
+        private ReadOnlySeparatedSpanList() { }
+
+        /// <summary>
+        /// Gets the length of this <see cref="ReadOnlySeparatedSpanList{TSpan, TSeparator}"/>.
+        /// </summary>
+        public abstract int Length { get; }
+
+        /// <summary>
+        /// Gets the spanned element at the specified index in the read-only list.
+        /// </summary>
+        /// <param name="index">
+        /// The zero-based index of the spanned element to get.
+        /// </param>
+        /// <returns>
+        /// The spanned element at the specified index in the read-only list.
+        /// </returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="index"/>is less than 0 or greater than or equal to <see cref="Count"/>.
+        /// </exception>
+        public abstract TSpan this[int index] { get; }
+
+        /// <summary>
+        /// Gets the number of spanned elements in the list.
+        /// </summary>
+        public abstract int Count { get; }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the list.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the list.
+        /// </returns>
+        public abstract IEnumerator<TSpan> GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Eutherion/Shared/Text/ReadOnlySpanList.cs
+++ b/Eutherion/Shared/Text/ReadOnlySpanList.cs
@@ -1,0 +1,97 @@
+﻿#region License
+/*********************************************************************************
+ * ReadOnlySpanList.cs
+ *
+ * Copyright (c) 2004-2019 Henk Nicolai
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+**********************************************************************************/
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Eutherion.Text
+{
+    /// <summary>
+    /// Represents a read-only list of spanned elements that can be accessed by index.
+    /// </summary>
+    /// <typeparam name="TSpan">
+    /// The type of spanned elements in the read-only list.
+    /// </typeparam>
+    public class ReadOnlySpanList<TSpan> : IReadOnlyList<TSpan> where TSpan : ISpan
+    {
+        /// <summary>
+        /// Gets the empty <see cref="ReadOnlySpanList{T}"/>.
+        /// </summary>
+        public static readonly ReadOnlySpanList<TSpan> Empty = new ReadOnlySpanList<TSpan>(Array.Empty<TSpan>());
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ReadOnlySpanList{T}"/>.
+        /// </summary>
+        /// <param name="source">
+        /// The elements of the list.
+        /// </param>
+        /// <returns>
+        /// The initialized <see cref="ReadOnlySpanList{T}"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> is null.
+        /// </exception>
+        public static ReadOnlySpanList<TSpan> Create(IEnumerable<TSpan> source)
+        {
+            if (source is ReadOnlySpanList<TSpan> readOnlyList) return readOnlyList;
+            var array = source.ToArrayEx();
+            return array.Length == 0 ? Empty : new ReadOnlySpanList<TSpan>(array);
+        }
+
+        private readonly TSpan[] array;
+
+        private ReadOnlySpanList(TSpan[] array) => this.array = array;
+
+        /// <summary>
+        /// Gets the spanned element at the specified index in the read-only list.
+        /// </summary>
+        /// <param name="index">
+        /// The zero-based index of the spanned element to get.
+        /// </param>
+        /// <returns>
+        /// The spanned element at the specified index in the read-only list.
+        /// </returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="index"/>is less than 0 or greater than or equal to <see cref="Count"/>.
+        /// </exception>
+        public TSpan this[int index] => array[index];
+
+        /// <summary>
+        /// Gets the number of spanned elements in the list.
+        /// </summary>
+        public int Count => array.Length;
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the list.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the list.
+        /// </returns>
+        public IEnumerator<TSpan> GetEnumerator()
+        {
+            foreach (TSpan element in array) yield return element;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Eutherion/Shared/Text/ReadOnlySpanList.cs
+++ b/Eutherion/Shared/Text/ReadOnlySpanList.cs
@@ -32,7 +32,7 @@ namespace Eutherion.Text
     /// <typeparam name="TSpan">
     /// The type of spanned elements in the read-only list.
     /// </typeparam>
-    public class ReadOnlySpanList<TSpan> : IReadOnlyList<TSpan> where TSpan : ISpan
+    public class ReadOnlySpanList<TSpan> : IReadOnlyList<TSpan>, ISpan where TSpan : ISpan
     {
         /// <summary>
         /// Gets the empty <see cref="ReadOnlySpanList{T}"/>.
@@ -51,16 +51,36 @@ namespace Eutherion.Text
         /// <exception cref="ArgumentNullException">
         /// <paramref name="source"/> is null.
         /// </exception>
+        /// <exception cref="ArgumentException">
+        /// One or more elements in <paramref name="source"/> are null.
+        /// </exception>
         public static ReadOnlySpanList<TSpan> Create(IEnumerable<TSpan> source)
         {
-            if (source is ReadOnlySpanList<TSpan> readOnlyList) return readOnlyList;
+            if (source is ReadOnlySpanList<TSpan> readOnlySpanList) return readOnlySpanList;
             var array = source.ToArrayEx();
             return array.Length == 0 ? Empty : new ReadOnlySpanList<TSpan>(array);
         }
 
         private readonly TSpan[] array;
 
-        private ReadOnlySpanList(TSpan[] array) => this.array = array;
+        private ReadOnlySpanList(TSpan[] source)
+        {
+            int length = 0;
+            for (int i = 0; i < source.Length; i++)
+            {
+                TSpan arrayElement = source[i];
+                if (arrayElement == null) throw new ArgumentException(nameof(source));
+                length += arrayElement.Length;
+            }
+
+            array = source;
+            Length = length;
+        }
+
+        /// <summary>
+        /// Gets the length of this <see cref="ReadOnlySpanList{TSpan}"/>.
+        /// </summary>
+        public int Length { get; }
 
         /// <summary>
         /// Gets the spanned element at the specified index in the read-only list.

--- a/Eutherion/Shared/Text/ReadOnlySpanList.cs
+++ b/Eutherion/Shared/Text/ReadOnlySpanList.cs
@@ -44,6 +44,8 @@ namespace Eutherion.Text
             public override int Count => 0;
 
             public override IEnumerator<TSpan> GetEnumerator() => EmptyEnumerator<TSpan>.Instance;
+
+            public override int GetElementOffset(int index) => throw new IndexOutOfRangeException();
         }
 
         private class OneElement : ReadOnlySpanList<TSpan>
@@ -63,19 +65,26 @@ namespace Eutherion.Text
             public override int Count => 1;
 
             public override IEnumerator<TSpan> GetEnumerator() => new SingleElementEnumerator<TSpan>(element);
+
+            public override int GetElementOffset(int index) => index == 0 ? 0 : throw new IndexOutOfRangeException();
         }
 
         private class TwoOrMoreElements : ReadOnlySpanList<TSpan>
         {
             private readonly TSpan[] array;
+            private readonly int[] arrayElementOffsets;
 
             public TwoOrMoreElements(TSpan[] source)
             {
-                int length = 0;
-                for (int i = 0; i < source.Length; i++)
+                if (source[0] == null) throw new ArgumentException(nameof(source));
+                int length = source[0].Length;
+                arrayElementOffsets = new int[source.Length - 1];
+
+                for (int i = 1; i < source.Length; i++)
                 {
                     TSpan arrayElement = source[i];
                     if (arrayElement == null) throw new ArgumentException(nameof(source));
+                    arrayElementOffsets[i - 1] = length;
                     length += arrayElement.Length;
                 }
 
@@ -90,6 +99,8 @@ namespace Eutherion.Text
             public override int Count => array.Length;
 
             public override IEnumerator<TSpan> GetEnumerator() => ((ICollection<TSpan>)array).GetEnumerator();
+
+            public override int GetElementOffset(int index) => index == 0 ? 0 : arrayElementOffsets[index - 1];
         }
 
         /// <summary>
@@ -156,5 +167,20 @@ namespace Eutherion.Text
         public abstract IEnumerator<TSpan> GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Gets the start position of the spanned element at the specified index
+        /// relative to the start position of the first element.
+        /// </summary>
+        /// <param name="index">
+        /// The zero-based index of the spanned element.
+        /// </param>
+        /// <returns>
+        /// The start position of the spanned element relative to the start position of the first element.
+        /// </returns>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="index"/>is less than 0 or greater than or equal to <see cref="Count"/>.
+        /// </exception>
+        public abstract int GetElementOffset(int index);
     }
 }

--- a/Eutherion/Shared/Text/TextElement.cs
+++ b/Eutherion/Shared/Text/TextElement.cs
@@ -31,7 +31,7 @@ namespace Eutherion.Text
     /// The type of terminal symbols to index.
     /// See also: https://en.wikipedia.org/wiki/Terminal_and_nonterminal_symbols
     /// </typeparam>
-    public class TextElement<TTerminal>
+    public class TextElement<TTerminal> : ISpan
     {
         private int start;
         private int length;

--- a/Eutherion/Shared/Utils/SpecializedEnumerable.cs
+++ b/Eutherion/Shared/Utils/SpecializedEnumerable.cs
@@ -1,0 +1,122 @@
+﻿#region License
+/*********************************************************************************
+ * SpecializedEnumerable.cs
+ *
+ * Copyright (c) 2004-2019 Henk Nicolai
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+**********************************************************************************/
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Eutherion.Utils
+{
+    /// <summary>
+    /// Utility <see cref="IEnumerable{T}"/> that enumerates no elements of the given type.
+    /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the enumerated elements.
+    /// </typeparam>
+    public struct EmptyEnumerable<TResult> : IEnumerable<TResult>
+    {
+        /// <summary>
+        /// Returns an <see cref="EmptyEnumerator{TResult}"/> which enumerates no elements of the given type.
+        /// </summary>
+        public IEnumerator<TResult> GetEnumerator() => EmptyEnumerator<TResult>.Instance;
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// Utility <see cref="IEnumerator{T}"/> that enumerates no elements of the given type.
+    /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the enumerated elements.
+    /// </typeparam>
+    public class EmptyEnumerator<TResult> : IEnumerator<TResult>
+    {
+        /// <summary>
+        /// Gets the only <see cref="EmptyEnumerator{TResult}"/> instance.
+        /// </summary>
+        public static readonly EmptyEnumerator<TResult> Instance = new EmptyEnumerator<TResult>();
+
+        private EmptyEnumerator() { }
+
+        void IEnumerator.Reset() { }
+        bool IEnumerator.MoveNext() => false;
+        TResult IEnumerator<TResult>.Current => default;
+        object IEnumerator.Current => default;
+        void IDisposable.Dispose() { }
+    }
+
+    /// <summary>
+    /// Utility <see cref="IEnumerable{T}"/> that enumerates a single element of the given type.
+    /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the enumerated elements.
+    /// </typeparam>
+    public struct SingleElementEnumerable<TResult> : IEnumerable<TResult>
+    {
+        /// <summary>
+        /// Gets or sets the element to enumerate.
+        /// </summary>
+        public TResult Element;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SingleElementEnumerable{TResult}"/>.
+        /// </summary>
+        /// <param name="element">
+        /// The single element to enumerate.
+        /// </param>
+        public SingleElementEnumerable(TResult element) => Element = element;
+
+        /// <summary>
+        /// Returns a <see cref="SingleElementEnumerator{TResult}"/> which enumerates <see cref="Element"/>.
+        /// </summary>
+        public IEnumerator<TResult> GetEnumerator() => new SingleElementEnumerator<TResult>(Element);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// Utility <see cref="IEnumerator{T}"/> that enumerates a single element of the given type.
+    /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the enumerated elements.
+    /// </typeparam>
+    public class SingleElementEnumerator<TResult> : IEnumerator<TResult>
+    {
+        private readonly TResult element;
+        private bool yielded;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SingleElementEnumerator{TResult}"/>.
+        /// </summary>
+        /// <param name="element">
+        /// The single element to enumerate.
+        /// </param>
+        public SingleElementEnumerator(TResult element) => this.element = element;
+
+        // When called from a foreach construct, it goes:
+        // MoveNext() Current MoveNext() Dispose()
+        void IEnumerator.Reset() => yielded = false;
+        bool IEnumerator.MoveNext() { if (yielded) return false; yielded = true; return true; }
+        TResult IEnumerator<TResult>.Current => element;
+        object IEnumerator.Current => element;
+        void IDisposable.Dispose() { }
+    }
+}

--- a/Eutherion/Tests/JsonSyntaxTests.cs
+++ b/Eutherion/Tests/JsonSyntaxTests.cs
@@ -78,6 +78,19 @@ namespace Eutherion.Shared.Tests
         }
 
         [Fact]
+        public void JsonSymbolsWithLengthOne()
+        {
+            // As long as there's code around which depends on these symbols having length 1, this unit test is needed.
+            Assert.Equal(1, JsonColon.Value.Length);
+            Assert.Equal(1, JsonComma.Value.Length);
+            Assert.Equal(1, JsonCurlyClose.Value.Length);
+            Assert.Equal(1, JsonCurlyOpen.Value.Length);
+            Assert.Equal(1, JsonSquareBracketClose.Value.Length);
+            Assert.Equal(1, JsonSquareBracketOpen.Value.Length);
+            Assert.Equal(1, new JsonUnknownSymbol("\\0").Length);
+        }
+
+        [Fact]
         public void NullValueShouldThrow()
         {
             Assert.Throws<ArgumentNullException>(() => new JsonString(null, 0));

--- a/Eutherion/Win/Eutherion.Win.csproj
+++ b/Eutherion/Win/Eutherion.Win.csproj
@@ -86,10 +86,10 @@
     <Compile Include="Storage\SettingKey.cs" />
     <Compile Include="Storage\SettingObject.cs" />
     <Compile Include="Storage\SettingProperty.cs" />
-    <Compile Include="Storage\SettingReader.cs" />
     <Compile Include="Storage\SettingsAutoSave.cs" />
     <Compile Include="Storage\SettingSchema.cs" />
     <Compile Include="Storage\SettingsFile.cs" />
+    <Compile Include="Storage\SettingSyntaxTree.cs" />
     <Compile Include="Storage\SettingWriter.cs" />
     <Compile Include="Storage\SubFolderNameType.cs" />
     <Compile Include="UIActions\UIActionBindings.cs" />

--- a/Eutherion/Win/Storage/PType.List.cs
+++ b/Eutherion/Win/Storage/PType.List.cs
@@ -44,11 +44,11 @@ namespace Eutherion.Win.Storage
                 out ItemT convertedTargetValue,
                 out PValue value)
             {
-                JsonValueSyntax itemNode = jsonListSyntax.ElementNodes[itemIndex].ValueNode.ContentNode;
+                JsonValueSyntax itemNode = jsonListSyntax.ListItemNodes[itemIndex].ValueNode.ContentNode;
 
                 int itemNodeStart = listSyntaxStartPosition
                                   + jsonListSyntax.GetElementNodeStart(itemIndex)
-                                  + jsonListSyntax.ElementNodes[itemIndex].ValueNode.BackgroundBefore.Length;
+                                  + jsonListSyntax.ListItemNodes[itemIndex].ValueNode.BackgroundBefore.Length;
 
                 return itemType.TryCreateValue(
                     json,
@@ -108,7 +108,7 @@ namespace Eutherion.Win.Storage
                 int listSyntaxStartPosition,
                 List<JsonErrorInfo> errors)
             {
-                if (jsonListSyntax.FilteredElementNodeCount == ExpectedItemCount
+                if (jsonListSyntax.FilteredListItemNodeCount == ExpectedItemCount
                     && TryCreateItemValue(ItemTypes.Item1, json, jsonListSyntax, 0, listSyntaxStartPosition, errors, out T1 value1, out PValue itemValue1)
                     && TryCreateItemValue(ItemTypes.Item2, json, jsonListSyntax, 1, listSyntaxStartPosition, errors, out T2 value2, out PValue itemValue2))
                 {
@@ -159,7 +159,7 @@ namespace Eutherion.Win.Storage
                 int listSyntaxStartPosition,
                 List<JsonErrorInfo> errors)
             {
-                if (jsonListSyntax.FilteredElementNodeCount == ExpectedItemCount
+                if (jsonListSyntax.FilteredListItemNodeCount == ExpectedItemCount
                     && TryCreateItemValue(ItemTypes.Item1, json, jsonListSyntax, 0, listSyntaxStartPosition, errors, out T1 value1, out PValue itemValue1)
                     && TryCreateItemValue(ItemTypes.Item2, json, jsonListSyntax, 1, listSyntaxStartPosition, errors, out T2 value2, out PValue itemValue2)
                     && TryCreateItemValue(ItemTypes.Item3, json, jsonListSyntax, 2, listSyntaxStartPosition, errors, out T3 value3, out PValue itemValue3)

--- a/Eutherion/Win/Storage/SettingCopy.cs
+++ b/Eutherion/Win/Storage/SettingCopy.cs
@@ -185,19 +185,21 @@ namespace Eutherion.Win.Storage
         /// </summary>
         internal List<JsonErrorInfo> TryLoadFromText(string json)
         {
-            if (SettingReader.TryParse(json, Schema, out SettingObject settingObject, out _, out List<JsonErrorInfo> errors))
+            var settingSyntaxTree = SettingSyntaxTree.ParseSettings(json, Schema);
+
+            if (settingSyntaxTree.SettingObject != null)
             {
                 // Error tolerance:
                 // 1) Even if there are errors, still load the map.
                 // 2) Don't clear the existing settings, only overwrite them.
                 //    The map might not contain all expected properties.
-                foreach (var kv in settingObject.Map)
+                foreach (var kv in settingSyntaxTree.SettingObject.Map)
                 {
                     KeyValueMapping[kv.Key] = kv.Value;
                 }
             }
 
-            return errors;
+            return settingSyntaxTree.Errors;
         }
     }
 }

--- a/Eutherion/Win/Storage/SettingSyntaxTree.cs
+++ b/Eutherion/Win/Storage/SettingSyntaxTree.cs
@@ -31,7 +31,7 @@ namespace Eutherion.Win.Storage
     {
         public static SettingSyntaxTree ParseSettings(string json, SettingSchema schema)
         {
-            JsonMultiValueSyntax rootNode = new JsonParser(json).TryParse(out List<JsonErrorInfo> errors);
+            JsonMultiValueSyntax rootNode = JsonParser.TryParse(json, out List<JsonErrorInfo> errors);
 
             if (rootNode.ValueNode.ContentNode is JsonMissingValueSyntax)
             {

--- a/Eutherion/Win/Storage/SettingsAutoSave.cs
+++ b/Eutherion/Win/Storage/SettingsAutoSave.cs
@@ -19,8 +19,6 @@
 **********************************************************************************/
 #endregion
 
-using Eutherion.Text.Json;
-using Eutherion.Utils;
 using System;
 using System.Collections.Generic;
 
@@ -46,14 +44,9 @@ namespace Eutherion.Win.Storage
                 {
                     // Load into a copy of RemoteSettings, preserving defaults.
                     var workingCopy = RemoteSettings.CreateWorkingCopy();
-                    var errors = workingCopy.TryLoadFromText(loadedText);
 
-                    if (errors.Count > 0)
-                    {
-                        // Leave RemoteSettings unchanged.
-                        errors.ForEach(x => new SettingsAutoSaveParseException(x).Trace());
-                    }
-                    else
+                    // Leave RemoteSettings unchanged if the loaded text contained any errors.
+                    if (workingCopy.TryLoadFromText(loadedText))
                     {
                         RemoteSettings = workingCopy.Commit();
                     }
@@ -169,17 +162,5 @@ namespace Eutherion.Win.Storage
         {
             autoSaveFile?.Dispose();
         }
-    }
-
-    internal class SettingsAutoSaveParseException : Exception
-    {
-        public static string AutoSaveFileParseMessage(JsonErrorInfo jsonErrorInfo)
-        {
-            string paramDisplayString = StringUtilities.ToDefaultParameterListDisplayString(jsonErrorInfo.Parameters);
-            return $"{jsonErrorInfo.ErrorCode}{paramDisplayString} at position {jsonErrorInfo.Start}, length {jsonErrorInfo.Length}";
-        }
-
-        public SettingsAutoSaveParseException(JsonErrorInfo jsonErrorInfo)
-            : base(AutoSaveFileParseMessage(jsonErrorInfo)) { }
     }
 }

--- a/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
+++ b/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
@@ -32,7 +32,7 @@ namespace Eutherion.Win.AppTemplate
     /// <summary>
     /// Describes the interaction between json syntax and a syntax editor.
     /// </summary>
-    public class JsonSyntaxDescriptor : SyntaxDescriptor<JsonSymbol, JsonErrorInfo>
+    public class JsonSyntaxDescriptor : SyntaxDescriptor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo>
     {
         public static readonly string JsonFileExtension = "json";
 
@@ -79,7 +79,7 @@ namespace Eutherion.Win.AppTemplate
             return (new JsonSymbolEnumerator(settingSyntaxTree.JsonRootNode), errors);
         }
 
-        public override Style GetStyle(SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor, JsonSymbol terminalSymbol)
+        public override Style GetStyle(SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor, JsonSymbol terminalSymbol)
             => JsonStyleSelector.Instance.Visit(terminalSymbol, syntaxEditor);
 
         public override int GetLength(JsonSymbol terminalSymbol)
@@ -95,7 +95,7 @@ namespace Eutherion.Win.AppTemplate
     /// <summary>
     /// A style selector for json syntax highlighting.
     /// </summary>
-    public class JsonStyleSelector : JsonSymbolVisitor<SyntaxEditor<JsonSymbol, JsonErrorInfo>, Style>
+    public class JsonStyleSelector : JsonSymbolVisitor<SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo>, Style>
     {
         private const int commentStyleIndex = 8;
         private const int valueStyleIndex = 9;
@@ -111,7 +111,7 @@ namespace Eutherion.Win.AppTemplate
 
         public static readonly JsonStyleSelector Instance = new JsonStyleSelector();
 
-        public static void InitializeStyles(SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public static void InitializeStyles(SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
         {
             syntaxEditor.Styles[commentStyleIndex].ForeColor = commentForeColor;
             commentFont.CopyTo(syntaxEditor.Styles[commentStyleIndex]);
@@ -124,22 +124,22 @@ namespace Eutherion.Win.AppTemplate
 
         private JsonStyleSelector() { }
 
-        public override Style DefaultVisit(JsonSymbol symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style DefaultVisit(JsonSymbol symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.DefaultStyle;
 
-        public override Style VisitComment(JsonComment symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style VisitComment(JsonComment symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.Styles[commentStyleIndex];
 
-        public override Style VisitErrorString(JsonErrorString symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style VisitErrorString(JsonErrorString symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.Styles[stringStyleIndex];
 
-        public override Style VisitString(JsonString symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style VisitString(JsonString symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.Styles[stringStyleIndex];
 
-        public override Style VisitUnterminatedMultiLineComment(JsonUnterminatedMultiLineComment symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style VisitUnterminatedMultiLineComment(JsonUnterminatedMultiLineComment symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.Styles[commentStyleIndex];
 
-        public override Style VisitValue(JsonValue symbol, SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor)
+        public override Style VisitValue(JsonValue symbol, SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor)
             => syntaxEditor.Styles[valueStyleIndex];
     }
 }

--- a/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
+++ b/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
@@ -59,14 +59,13 @@ namespace Eutherion.Win.AppTemplate
 
         public override LocalizedStringKey FileExtensionLocalizedKey => SharedLocalizedStringKeys.JsonFiles;
 
-        public override (IEnumerable<JsonSymbol>, List<JsonErrorInfo>) Parse(string code)
+        public override SettingSyntaxTree Parse(string code)
         {
             var settingSyntaxTree = SettingSyntaxTree.ParseSettings(code, schema);
-            var errors = settingSyntaxTree.Errors;
 
-            if (errors.Count > 0)
+            if (settingSyntaxTree.Errors.Count > 0)
             {
-                errors.Sort((x, y)
+                settingSyntaxTree.Errors.Sort((x, y)
                     => x.Start < y.Start ? -1
                     : x.Start > y.Start ? 1
                     : x.Length < y.Length ? -1
@@ -76,8 +75,14 @@ namespace Eutherion.Win.AppTemplate
                     : 0);
             }
 
-            return (new JsonSymbolEnumerator(settingSyntaxTree.JsonRootNode), errors);
+            return settingSyntaxTree;
         }
+
+        public override IEnumerable<JsonSymbol> GetTerminals(SettingSyntaxTree syntaxTree)
+            => new JsonSymbolEnumerator(syntaxTree.JsonRootNode);
+
+        public override IEnumerable<JsonErrorInfo> GetErrors(SettingSyntaxTree syntaxTree)
+            => syntaxTree.Errors;
 
         public override Style GetStyle(SyntaxEditor<SettingSyntaxTree, JsonSymbol, JsonErrorInfo> syntaxEditor, JsonSymbol terminalSymbol)
             => JsonStyleSelector.Instance.Visit(terminalSymbol, syntaxEditor);

--- a/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
+++ b/Sandra.UI/AppTemplate/JsonSyntaxDescriptor.cs
@@ -61,7 +61,8 @@ namespace Eutherion.Win.AppTemplate
 
         public override (IEnumerable<JsonSymbol>, List<JsonErrorInfo>) Parse(string code)
         {
-            SettingReader.TryParse(code, schema, out _, out JsonMultiValueSyntax rootNode, out List<JsonErrorInfo> errors);
+            var settingSyntaxTree = SettingSyntaxTree.ParseSettings(code, schema);
+            var errors = settingSyntaxTree.Errors;
 
             if (errors.Count > 0)
             {
@@ -75,7 +76,7 @@ namespace Eutherion.Win.AppTemplate
                     : 0);
             }
 
-            return (new JsonSymbolEnumerator(rootNode), errors);
+            return (new JsonSymbolEnumerator(settingSyntaxTree.JsonRootNode), errors);
         }
 
         public override Style GetStyle(SyntaxEditor<JsonSymbol, JsonErrorInfo> syntaxEditor, JsonSymbol terminalSymbol)

--- a/Sandra.UI/AppTemplate/Session.ToolForms.cs
+++ b/Sandra.UI/AppTemplate/Session.ToolForms.cs
@@ -132,7 +132,7 @@ namespace Eutherion.Win.AppTemplate
                     containsChanges: false);
             }
 
-            var settingsForm = new SyntaxEditorForm<JsonSymbol, JsonErrorInfo>(
+            var settingsForm = new SyntaxEditorForm<SettingSyntaxTree, JsonSymbol, JsonErrorInfo>(
                 codeAccessOption,
                 syntaxDescriptor,
                 codeFile,

--- a/Sandra.UI/AppTemplate/SyntaxEditor.cs
+++ b/Sandra.UI/AppTemplate/SyntaxEditor.cs
@@ -225,9 +225,9 @@ namespace Eutherion.Win.AppTemplate
 
             IndicatorClearRange(0, TextLength);
 
-            currentErrors = ReadOnlyList<TError>.Create(SyntaxDescriptor.GetErrors(syntaxTree));
+            CurrentErrors = ReadOnlyList<TError>.Create(SyntaxDescriptor.GetErrors(syntaxTree));
 
-            foreach (var error in currentErrors)
+            foreach (var error in CurrentErrors)
             {
                 var (errorStart, errorLength) = SyntaxDescriptor.GetErrorRange(error);
 
@@ -237,18 +237,14 @@ namespace Eutherion.Win.AppTemplate
             CurrentErrorsChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        private ReadOnlyList<TError> currentErrors = ReadOnlyList<TError>.Empty;
-
-        public int CurrentErrorCount => currentErrors.Count;
-
-        public IEnumerable<TError> CurrentErrors => currentErrors.Enumerate();
+        public ReadOnlyList<TError> CurrentErrors { get; private set; } = ReadOnlyList<TError>.Empty;
 
         public event EventHandler CurrentErrorsChanged;
 
         public void ActivateError(int errorIndex)
         {
             // Select the text that generated the error.
-            if (0 <= errorIndex && errorIndex < currentErrors.Count)
+            if (0 <= errorIndex && errorIndex < CurrentErrors.Count)
             {
                 // Determine how many lines are visible in the top half of the control.
                 int firstVisibleLine = FirstVisibleLine;
@@ -257,7 +253,7 @@ namespace Eutherion.Win.AppTemplate
 
                 // Then calculate which line should become the first visible line
                 // so the error line ends up in the middle of the control.
-                var (hotErrorStart, hotErrorLength) = SyntaxDescriptor.GetErrorRange(currentErrors[errorIndex]);
+                var (hotErrorStart, hotErrorLength) = SyntaxDescriptor.GetErrorRange(CurrentErrors[errorIndex]);
                 int hotErrorLine = LineFromPosition(hotErrorStart);
 
                 // hotErrorLine in view?
@@ -283,7 +279,7 @@ namespace Eutherion.Win.AppTemplate
         {
             if (textPosition >= 0 && textPosition < TextLength)
             {
-                foreach (var error in currentErrors)
+                foreach (var error in CurrentErrors)
                 {
                     var (errorStart, errorLength) = SyntaxDescriptor.GetErrorRange(error);
 

--- a/Sandra.UI/AppTemplate/SyntaxEditor.cs
+++ b/Sandra.UI/AppTemplate/SyntaxEditor.cs
@@ -20,7 +20,6 @@
 #endregion
 
 using Eutherion.Localization;
-using Eutherion.Text;
 using Eutherion.UIActions;
 using Eutherion.Utils;
 using Eutherion.Win.Storage;
@@ -37,20 +36,23 @@ namespace Eutherion.Win.AppTemplate
     /// <summary>
     /// Represents a <see cref="ScintillaEx"/> control with syntax highlighting.
     /// </summary>
+    /// <typeparam name="TSyntaxTree">
+    /// The type of syntax tree.
+    /// </typeparam>
     /// <typeparam name="TTerminal">
     /// The type of terminal symbol to display.
     /// </typeparam>
     /// <typeparam name="TError">
     /// The type of error to display.
     /// </typeparam>
-    public class SyntaxEditor<TTerminal, TError> : ScintillaEx
+    public class SyntaxEditor<TSyntaxTree, TTerminal, TError> : ScintillaEx
     {
         private const int ErrorIndicatorIndex = 8;
 
         /// <summary>
         /// Gets the syntax descriptor.
         /// </summary>
-        public SyntaxDescriptor<TTerminal, TError> SyntaxDescriptor { get; }
+        public SyntaxDescriptor<TSyntaxTree, TTerminal, TError> SyntaxDescriptor { get; }
 
         /// <summary>
         /// Gets the edited text file.
@@ -64,7 +66,7 @@ namespace Eutherion.Win.AppTemplate
         private bool containsChangesAtSavePoint;
 
         /// <summary>
-        /// Returns if this <see cref="SyntaxEditor{TTerminal, TError}"/> contains any unsaved changes.
+        /// Returns if this <see cref="SyntaxEditor{TSyntaxTree, TTerminal, TError}"/> contains any unsaved changes.
         /// If the text file could not be opened, true is returned.
         /// </summary>
         public bool ContainsChanges
@@ -76,19 +78,19 @@ namespace Eutherion.Win.AppTemplate
         private Style CallTipStyle => Styles[Style.CallTip];
 
         /// <summary>
-        /// Initializes a new instance of a <see cref="SyntaxEditor{TTerminal, TError}"/>.
+        /// Initializes a new instance of a <see cref="SyntaxEditor{TSyntaxTree, TTerminal, TError}"/>.
         /// </summary>
         /// <param name="syntaxDescriptor">
         /// The syntax descriptor.
         /// </param>
         /// <param name="codeFile">
         /// The code file to show and/or edit.
-        /// It is disposed together with this <see cref="SyntaxEditor{TTerminal, TError}"/>.
+        /// It is disposed together with this <see cref="SyntaxEditor{TSyntaxTree, TTerminal, TError}"/>.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="syntaxDescriptor"/> and/or <paramref name="codeFile"/> are null.
         /// </exception>
-        public SyntaxEditor(SyntaxDescriptor<TTerminal, TError> syntaxDescriptor,
+        public SyntaxEditor(SyntaxDescriptor<TSyntaxTree, TTerminal, TError> syntaxDescriptor,
                             WorkingCopyTextFile codeFile)
         {
             SyntaxDescriptor = syntaxDescriptor ?? throw new ArgumentNullException(nameof(syntaxDescriptor));
@@ -399,15 +401,18 @@ namespace Eutherion.Win.AppTemplate
     }
 
     /// <summary>
-    /// Describes the interaction between a syntax and how a <see cref="SyntaxDescriptor{TTerminal, TError}"/> displays it.
+    /// Describes the interaction between a syntax and how a <see cref="SyntaxDescriptor{TSyntaxTree, TTerminal, TError}"/> displays it.
     /// </summary>
+    /// <typeparam name="TSyntaxTree">
+    /// The type of syntax tree.
+    /// </typeparam>
     /// <typeparam name="TTerminal">
     /// The type of terminal symbol to display.
     /// </typeparam>
     /// <typeparam name="TError">
     /// The type of error to display.
     /// </typeparam>
-    public abstract class SyntaxDescriptor<TTerminal, TError>
+    public abstract class SyntaxDescriptor<TSyntaxTree, TTerminal, TError>
     {
         /// <summary>
         /// Gets the default file extension for this syntax.
@@ -427,7 +432,7 @@ namespace Eutherion.Win.AppTemplate
         /// <summary>
         /// Gets the style for a terminal symbol.
         /// </summary>
-        public abstract Style GetStyle(SyntaxEditor<TTerminal, TError> syntaxEditor, TTerminal terminalSymbol);
+        public abstract Style GetStyle(SyntaxEditor<TSyntaxTree, TTerminal, TError> syntaxEditor, TTerminal terminalSymbol);
 
         /// <summary>
         /// Gets the length of a terminal symbol.

--- a/Sandra.UI/AppTemplate/SyntaxEditorForm.cs
+++ b/Sandra.UI/AppTemplate/SyntaxEditorForm.cs
@@ -111,7 +111,7 @@ namespace Eutherion.Win.AppTemplate
 
             // If there is no errorsTextBox, splitter will remain null,
             // and no splitter distance needs to be restored or auto-saved.
-            if (SyntaxEditor.ReadOnly && SyntaxEditor.CurrentErrorCount == 0)
+            if (SyntaxEditor.ReadOnly && SyntaxEditor.CurrentErrors.Count == 0)
             {
                 // No errors while read-only: do not display an errors textbox.
                 Controls.Add(SyntaxEditor);
@@ -345,7 +345,7 @@ namespace Eutherion.Win.AppTemplate
 
             try
             {
-                if (SyntaxEditor.CurrentErrorCount == 0)
+                if (SyntaxEditor.CurrentErrors.Count == 0)
                 {
                     errorsListBox.Items.Clear();
                     errorsListBox.Items.Add(noErrorsString.DisplayText.Value);
@@ -475,7 +475,7 @@ namespace Eutherion.Win.AppTemplate
         {
             if (errorsListBox == null) return UIActionVisibility.Hidden;
 
-            int errorCount = SyntaxEditor.CurrentErrorCount;
+            int errorCount = SyntaxEditor.CurrentErrors.Count;
             if (errorCount == 0) return UIActionVisibility.Disabled;
 
             if (perform)
@@ -495,7 +495,7 @@ namespace Eutherion.Win.AppTemplate
         {
             if (errorsListBox == null) return UIActionVisibility.Hidden;
 
-            int errorCount = SyntaxEditor.CurrentErrorCount;
+            int errorCount = SyntaxEditor.CurrentErrors.Count;
             if (errorCount == 0) return UIActionVisibility.Disabled;
 
             if (perform)

--- a/Sandra.UI/AppTemplate/SyntaxEditorForm.cs
+++ b/Sandra.UI/AppTemplate/SyntaxEditorForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace Eutherion.Win.AppTemplate
 {
-    public class SyntaxEditorForm<TTerminal, TError> : MenuCaptionBarForm, IWeakEventTarget
+    public class SyntaxEditorForm<TSyntaxTree, TTerminal, TError> : MenuCaptionBarForm, IWeakEventTarget
     {
         private const string ChangedMarker = "• ";
 
@@ -53,10 +53,10 @@ namespace Eutherion.Win.AppTemplate
         private readonly LocalizedString noErrorsString;
         private readonly LocalizedString errorLocationString;
 
-        public SyntaxEditor<TTerminal, TError> SyntaxEditor { get; }
+        public SyntaxEditor<TSyntaxTree, TTerminal, TError> SyntaxEditor { get; }
 
         public SyntaxEditorForm(SyntaxEditorCodeAccessOption codeAccessOption,
-                                SyntaxDescriptor<TTerminal, TError> syntaxDescriptor,
+                                SyntaxDescriptor<TSyntaxTree, TTerminal, TError> syntaxDescriptor,
                                 WorkingCopyTextFile codeFile,
                                 SettingProperty<PersistableFormState> formStateSetting,
                                 SettingProperty<int> errorHeightSetting,
@@ -65,7 +65,7 @@ namespace Eutherion.Win.AppTemplate
             this.formStateSetting = formStateSetting;
             this.errorHeightSetting = errorHeightSetting;
 
-            SyntaxEditor = new SyntaxEditor<TTerminal, TError>(syntaxDescriptor, codeFile)
+            SyntaxEditor = new SyntaxEditor<TSyntaxTree, TTerminal, TError>(syntaxDescriptor, codeFile)
             {
                 Dock = DockStyle.Fill,
                 ReadOnly = codeAccessOption == SyntaxEditorCodeAccessOption.ReadOnly,

--- a/Sandra.UI/PgnSyntaxDescriptor.cs
+++ b/Sandra.UI/PgnSyntaxDescriptor.cs
@@ -38,12 +38,18 @@ namespace Sandra.UI
 
         public override LocalizedStringKey FileExtensionLocalizedKey => LocalizedStringKeys.PgnFiles;
 
-        public override (IEnumerable<PgnSymbol>, List<PgnErrorInfo>) Parse(string code)
+        public override PgnSyntaxTree Parse(string code)
         {
             int length = code.Length;
-            if (length == 0) return (Enumerable.Empty<PgnSymbol>(), new List<PgnErrorInfo>());
-            return (new PgnSymbol[] { new PgnSymbol(length) }, new List<PgnErrorInfo>());
+            if (length == 0) return new PgnSyntaxTree(Enumerable.Empty<PgnSymbol>());
+            return new PgnSyntaxTree(new PgnSymbol[] { new PgnSymbol(length) });
         }
+
+        public override IEnumerable<PgnSymbol> GetTerminals(PgnSyntaxTree syntaxTree)
+            => syntaxTree.Terminals;
+
+        public override IEnumerable<PgnErrorInfo> GetErrors(PgnSyntaxTree syntaxTree)
+            => syntaxTree.Errors;
 
         public override Style GetStyle(SyntaxEditor<PgnSyntaxTree, PgnSymbol, PgnErrorInfo> syntaxEditor, PgnSymbol terminalSymbol)
             => syntaxEditor.DefaultStyle;
@@ -60,6 +66,10 @@ namespace Sandra.UI
 
     public class PgnSyntaxTree
     {
+        public readonly IEnumerable<PgnSymbol> Terminals;
+        public readonly IEnumerable<PgnErrorInfo> Errors = Enumerable.Empty<PgnErrorInfo>();
+
+        public PgnSyntaxTree(IEnumerable<PgnSymbol> terminals) => Terminals = terminals;
     }
 
     public class PgnSymbol

--- a/Sandra.UI/PgnSyntaxDescriptor.cs
+++ b/Sandra.UI/PgnSyntaxDescriptor.cs
@@ -30,7 +30,7 @@ namespace Sandra.UI
     /// <summary>
     /// Describes the interaction between PGN syntax and a syntax editor.
     /// </summary>
-    public class PgnSyntaxDescriptor : SyntaxDescriptor<PgnSymbol, PgnErrorInfo>
+    public class PgnSyntaxDescriptor : SyntaxDescriptor<PgnSyntaxTree, PgnSymbol, PgnErrorInfo>
     {
         public static readonly string PgnFileExtension = "pgn";
 
@@ -45,7 +45,7 @@ namespace Sandra.UI
             return (new PgnSymbol[] { new PgnSymbol(length) }, new List<PgnErrorInfo>());
         }
 
-        public override Style GetStyle(SyntaxEditor<PgnSymbol, PgnErrorInfo> syntaxEditor, PgnSymbol terminalSymbol)
+        public override Style GetStyle(SyntaxEditor<PgnSyntaxTree, PgnSymbol, PgnErrorInfo> syntaxEditor, PgnSymbol terminalSymbol)
             => syntaxEditor.DefaultStyle;
 
         public override int GetLength(PgnSymbol terminalSymbol)
@@ -56,6 +56,10 @@ namespace Sandra.UI
 
         public override string GetErrorMessage(PgnErrorInfo error)
             => error.Message;
+    }
+
+    public class PgnSyntaxTree
+    {
     }
 
     public class PgnSymbol

--- a/Sandra.UI/SandraChessMainForm.cs
+++ b/Sandra.UI/SandraChessMainForm.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 
 namespace Sandra.UI
 {
-    using PgnForm = SyntaxEditorForm<PgnSymbol, PgnErrorInfo>;
+    using PgnForm = SyntaxEditorForm<PgnSyntaxTree, PgnSymbol, PgnErrorInfo>;
 
     internal class SandraChessMainForm : SingleInstanceMainForm
     {


### PR DESCRIPTION
- Improve syntax descriptor API so a syntax tree can be stored in the syntax editor, and eventually be able to initialize styles lazily - important for large files.
- Improve JsonParser so it now reports errors on values following illegal control symbols at the top level of the syntax tree. (E.g. "{[}] x" now properly reports the unknown symbol 'x'.)
- Share code in utility classes ReadOnlySpanList and ReadOnlySeparatedSpanList, which the PGN parser will later also use.
- Add EmptyEnumerable, EmptyEnumerator, SingleElementEnumerable and SingleElementEnumerator utilities.
